### PR TITLE
feat(nav): restructura del menú principal — 7 secciones con visibilidad por rol

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import ArticulosPage from './pages/articulos'
 import FacturacionPage from './pages/facturacion'
 import LoginPage from './pages/login'
 import UsersPage from './pages/users'
+import InicioPage from './pages/inicio'
+import LogisticaPage from './pages/logistica'
+import FinanzasPage from './pages/finanzas'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 
 function ProtectedRoute() {
@@ -38,7 +41,7 @@ function LoginRoute() {
     )
   }
   if (status === 'authenticated') {
-    return <Navigate to="/clientes" replace />
+    return <Navigate to="/inicio" replace />
   }
   return <LoginPage />
 }
@@ -55,7 +58,7 @@ function RootRedirect() {
     )
   }
   if (status === 'authenticated') {
-    return <Navigate to="/clientes" replace />
+    return <Navigate to="/inicio" replace />
   }
   return <Navigate to="/login" replace />
 }
@@ -72,10 +75,16 @@ function AppRoutes() {
             </Layout>
           }
         >
+          {/* Home */}
+          <Route path="inicio" element={<InicioPage />} />
+          {/* Existing modules — keep original URLs bookmark-safe */}
           <Route path="clientes" element={<ClientesPage />} />
           <Route path="articulos" element={<ArticulosPage />} />
           <Route path="facturacion" element={<FacturacionPage />} />
           <Route path="users" element={<UsersPage />} />
+          {/* New section stubs — real pages delivered in Sprint 2 */}
+          <Route path="logistica" element={<LogisticaPage />} />
+          <Route path="finanzas" element={<FinanzasPage />} />
         </Route>
       </Route>
       <Route path="/" element={<RootRedirect />} />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,23 +2,82 @@ import { useState, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import LanguageSelect from '@/components/LanguageSelect'
-import { CanAccess } from '@/components/CanAccess'
 import { useAuth } from '@/contexts/AuthContext'
+import type { UserRole } from '@/lib/rbac'
 
 interface LayoutProps {
   children: React.ReactNode
 }
 
+/**
+ * @en Nav sections and the roles that can see each one.
+ *     `null` means visible to every authenticated user.
+ * @es Secciones del nav y los roles que pueden verlas.
+ *     `null` significa visible para todo usuario autenticado.
+ * @pt-BR Seções do nav e os papéis que podem visualizá-las.
+ *     `null` significa visível para todo usuário autenticado.
+ */
+const NAV_SECTIONS: {
+  key: string
+  path: string
+  icon: string
+  roles: readonly UserRole[] | null
+}[] = [
+  {
+    key: 'inicio',
+    path: '/inicio',
+    icon: '🏠',
+    roles: null,
+  },
+  {
+    key: 'ventas',
+    path: '/facturacion',
+    icon: '💰',
+    roles: ['owner', 'manager', 'seller', 'billing', 'cashier'],
+  },
+  {
+    key: 'clientes',
+    path: '/clientes',
+    icon: '📋',
+    roles: ['owner', 'manager', 'seller', 'backoffice', 'collections', 'finance', 'auditor'],
+  },
+  {
+    key: 'catalogo',
+    path: '/articulos',
+    icon: '📦',
+    roles: ['owner', 'manager', 'seller', 'backoffice', 'warehouse_op', 'warehouse_lead', 'logistics_planner'],
+  },
+  {
+    key: 'logistica',
+    path: '/logistica',
+    icon: '🚚',
+    roles: ['owner', 'manager', 'warehouse_op', 'warehouse_lead', 'logistics_planner', 'driver'],
+  },
+  {
+    key: 'finanzas',
+    path: '/finanzas',
+    icon: '💹',
+    roles: ['owner', 'manager', 'billing', 'cashier', 'collections', 'finance', 'auditor'],
+  },
+  {
+    key: 'configuracion',
+    path: '/users',
+    icon: '⚙️',
+    roles: ['owner', 'manager'],
+  },
+]
+
 export default function Layout({ children }: LayoutProps) {
   const { t } = useTranslation('common')
   const { logout, status, claims } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
+
   const [isDark, setIsDark] = useState(() => {
     // Lazy initializer: reads localStorage once at mount, no extra render
     const saved = localStorage.getItem('theme')
     return saved ? saved === 'dark' : true
   })
-  const location = useLocation()
 
   useEffect(() => {
     const root = document.documentElement
@@ -39,14 +98,21 @@ export default function Layout({ children }: LayoutProps) {
 
   const isActive = (path: string) => location.pathname === path
 
+  const userRole = claims?.role ?? null
+  const visibleSections = NAV_SECTIONS.filter(
+    (s) => s.roles === null || (userRole !== null && s.roles.includes(userRole)),
+  )
+
   return (
     <div className="flex h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100">
       {/* Sidebar */}
-      <aside className="w-64 bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700 flex flex-col" aria-label={t('nav.clientes') + ' / ' + t('nav.articulos') + ' / ' + t('nav.facturacion')}>
+      <aside
+        className="w-64 bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700 flex flex-col"
+        aria-label={t('nav.main')}
+      >
         {/* Logo / Header */}
         <div className="p-6 border-b border-slate-200 dark:border-slate-700">
           <h1 className="text-2xl font-bold text-blue-600 dark:text-blue-400">{t('app.name')}</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{t('app.version')}</p>
           {status === 'authenticated' && claims ? (
             <p className="mt-3 text-xs text-slate-500 dark:text-slate-400" data-testid="auth-user-label">
               {t('auth.userLabel', { username: claims.username, role: claims.role })}
@@ -55,49 +121,21 @@ export default function Layout({ children }: LayoutProps) {
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 p-4 space-y-2" aria-label={t('nav.main')}>
-          <Link
-            to="/clientes"
-            className={`block px-4 py-3 rounded transition ${
-              isActive('/clientes')
-                ? 'bg-blue-600 text-white'
-                : 'text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700'
-            }`}
-          >
-            📋 {t('nav.clientes')}
-          </Link>
-          <Link
-            to="/articulos"
-            className={`block px-4 py-3 rounded transition ${
-              isActive('/articulos')
-                ? 'bg-blue-600 text-white'
-                : 'text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700'
-            }`}
-          >
-            📦 {t('nav.articulos')}
-          </Link>
-          <Link
-            to="/facturacion"
-            className={`block px-4 py-3 rounded transition ${
-              isActive('/facturacion')
-                ? 'bg-blue-600 text-white'
-                : 'text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700'
-            }`}
-          >
-            🧾 {t('nav.facturacion')}
-          </Link>
-          <CanAccess permission="users.manage">
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto" aria-label={t('nav.main')}>
+          {visibleSections.map((section) => (
             <Link
-              to="/users"
-              className={`block px-4 py-3 rounded transition ${
-                isActive('/users')
+              key={section.key}
+              to={section.path}
+              className={`flex items-center gap-3 px-4 py-3 rounded transition ${
+                isActive(section.path)
                   ? 'bg-blue-600 text-white'
                   : 'text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700'
               }`}
             >
-              👤 {t('nav.users')}
+              <span aria-hidden="true">{section.icon}</span>
+              {t(`nav.${section.key}`)}
             </Link>
-          </CanAccess>
+          ))}
         </nav>
 
         {/* Language, theme, session */}
@@ -110,16 +148,6 @@ export default function Layout({ children }: LayoutProps) {
           />
           <button
             type="button"
-            onClick={() => {
-              void logout()
-            }}
-            className="w-full mb-2 px-4 py-2 rounded bg-red-600 hover:bg-red-700 transition text-white"
-            data-testid="logout-button"
-          >
-            {t('auth.logout')}
-          </button>
-          <button
-            type="button"
             onClick={toggleTheme}
             className="w-full px-4 py-2 rounded bg-slate-200 hover:bg-slate-300 dark:bg-slate-700 dark:hover:bg-slate-600 transition text-slate-800 dark:text-slate-200"
             title={t('theme.toggleTitle')}
@@ -128,14 +156,14 @@ export default function Layout({ children }: LayoutProps) {
           </button>
           <button
             type="button"
-            data-testid="layout-logout"
-            className="w-full px-4 py-2 rounded border border-slate-300 bg-white hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:hover:bg-slate-700 transition text-slate-800 dark:text-slate-200"
+            data-testid="logout-button"
+            className="w-full px-4 py-2 rounded bg-red-600 hover:bg-red-700 transition text-white"
             onClick={async () => {
               await logout()
               navigate('/login', { replace: true })
             }}
           >
-            {t('session.logout')}
+            {t('auth.logout')}
           </button>
         </div>
       </aside>
@@ -148,11 +176,17 @@ export default function Layout({ children }: LayoutProps) {
             {t('app.tagline')}
           </h2>
           <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-            💡 {t('shortcuts.title')}: <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">F2</kbd> {t('shortcuts.search')} •
-            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs ml-1">F3</kbd> {t('shortcuts.new')} •
-            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs ml-1">F5</kbd> {t('shortcuts.save')} •
-            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs ml-1">Esc</kbd> {t('shortcuts.cancel')} •
-            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs ml-1">↑↓</kbd> {t('shortcuts.navigate')}
+            💡 {t('shortcuts.title')}:{' '}
+            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">F2</kbd>{' '}
+            {t('shortcuts.search')} •{' '}
+            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">F3</kbd>{' '}
+            {t('shortcuts.new')} •{' '}
+            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">F5</kbd>{' '}
+            {t('shortcuts.save')} •{' '}
+            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">Esc</kbd>{' '}
+            {t('shortcuts.cancel')} •{' '}
+            <kbd className="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs">↑↓</kbd>{' '}
+            {t('shortcuts.navigate')}
           </p>
         </header>
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,12 +1,17 @@
 {
   "app": {
     "name": "BizCode",
-    "version": "v0.1.0 MVP",
     "tagline": "Commercial Management System"
   },
   "nav": {
     "main": "Main navigation",
+    "inicio": "Home",
+    "ventas": "Sales",
     "clientes": "Customers",
+    "catalogo": "Catalog",
+    "logistica": "Logistics",
+    "finanzas": "Finance",
+    "configuracion": "Settings",
     "articulos": "Products",
     "facturacion": "Invoicing",
     "users": "Users"
@@ -75,7 +80,8 @@
   "status": {
     "loading": "Loading...",
     "active": "Active",
-    "inactive": "Inactive"
+    "inactive": "Inactive",
+    "comingSoon": "Coming soon in v0.2.0"
   },
   "errors": {
     "generic": "Error saving",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1,12 +1,17 @@
 {
   "app": {
     "name": "BizCode",
-    "version": "v0.1.0 MVP",
     "tagline": "Sistema de Gestión Comercial"
   },
   "nav": {
     "main": "Navegación principal",
+    "inicio": "Inicio",
+    "ventas": "Ventas",
     "clientes": "Clientes",
+    "catalogo": "Catálogo",
+    "logistica": "Logística",
+    "finanzas": "Finanzas",
+    "configuracion": "Configuración",
     "articulos": "Artículos",
     "facturacion": "Facturación",
     "users": "Usuarios"
@@ -75,7 +80,8 @@
   "status": {
     "loading": "Cargando...",
     "active": "Activo",
-    "inactive": "Inactivo"
+    "inactive": "Inactivo",
+    "comingSoon": "Próximamente disponible en v0.2.0"
   },
   "errors": {
     "generic": "Error al guardar",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -1,12 +1,17 @@
 {
   "app": {
     "name": "BizCode",
-    "version": "v0.1.0 MVP",
     "tagline": "Sistema de Gestão Comercial"
   },
   "nav": {
     "main": "Navegação principal",
+    "inicio": "Início",
+    "ventas": "Vendas",
     "clientes": "Clientes",
+    "catalogo": "Catálogo",
+    "logistica": "Logística",
+    "finanzas": "Finanças",
+    "configuracion": "Configurações",
     "articulos": "Produtos",
     "facturacion": "Faturamento",
     "users": "Usuários"
@@ -75,7 +80,8 @@
   "status": {
     "loading": "Carregando...",
     "active": "Ativo",
-    "inactive": "Inativo"
+    "inactive": "Inativo",
+    "comingSoon": "Em breve disponível em v0.2.0"
   },
   "errors": {
     "generic": "Erro ao salvar",

--- a/src/pages/finanzas/index.tsx
+++ b/src/pages/finanzas/index.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next'
+
+/**
+ * @en Finance placeholder — reports and collections covered in Issue #33.
+ * @es Placeholder finanzas — reportes y cobros cubiertos en Issue #33.
+ * @pt-BR Placeholder finanças — relatórios e cobranças cobertos na Issue #33.
+ */
+export default function FinanzasPage() {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
+        {t('nav.finanzas')}
+      </h1>
+      <p className="text-slate-500 dark:text-slate-400 text-sm">
+        {t('status.comingSoon')}
+      </p>
+    </div>
+  )
+}

--- a/src/pages/inicio/index.tsx
+++ b/src/pages/inicio/index.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next'
+
+/**
+ * @en Home / dashboard placeholder — replaced by the real KPI dashboard in Issue #29.
+ * @es Página de inicio — placeholder reemplazado por el dashboard real en Issue #29.
+ * @pt-BR Página inicial — placeholder substituído pelo dashboard real na Issue #29.
+ */
+export default function InicioPage() {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
+        {t('nav.inicio')}
+      </h1>
+      <p className="text-slate-500 dark:text-slate-400 text-sm">
+        {t('status.comingSoon')}
+      </p>
+    </div>
+  )
+}

--- a/src/pages/logistica/index.tsx
+++ b/src/pages/logistica/index.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next'
+
+/**
+ * @en Logistics placeholder — delivery zones and order dispatch covered in Issues #30–#32.
+ * @es Placeholder logística — zonas de entrega y despacho cubiertos en Issues #30–#32.
+ * @pt-BR Placeholder logística — zonas de entrega e despacho cobertos nas Issues #30–#32.
+ */
+export default function LogisticaPage() {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
+        {t('nav.logistica')}
+      </h1>
+      <p className="text-slate-500 dark:text-slate-400 text-sm">
+        {t('status.comingSoon')}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumen - Reemplaza los 4 links planos del sidebar por 7 secciones: **Inicio, Ventas, Clientes, Cat├ílogo, Log├¡stica, Finanzas, Configuraci├│n** - Cada secci├│n se filtra por rol con un array `NAV_SECTIONS` en `Layout.tsx` (sin `CanAccess` en nav ÔÇö la seguridad la enforce la API) - Rutas `/inicio`, `/logistica`, `/finanzas` con p├íginas placeholder (reemplazadas por p├íginas reales en Sprint 2) - `/ ` y post-login redirigen a `/inicio` en lugar de `/clientes` - i18n: nuevas claves `nav.*` y `status.comingSoon` en ES/EN/PT-BR - Consolidado el duplicado de botones de logout en uno  ## Matriz de visibilidad | Secci├│n       | owner/mgr | seller | backoffice | warehouse | driver | billing/cashier | finance/auditor | |---------------|:---------:|:------:|:----------:|:---------:|:------:|:---------------:|:---------------:| | Inicio        | Ô£à | Ô£à | Ô£à | Ô£à | Ô£à | Ô£à | Ô£à | | Ventas        | Ô£à | Ô£à | ÔØî | ÔØî | ÔØî | Ô£à | ÔØî | | Clientes      | Ô£à | Ô£à | Ô£à | ÔØî | ÔØî | ÔØî | Ô£à | | Cat├ílogo      | Ô£à | Ô£à | Ô£à | Ô£à | ÔØî | ÔØî | ÔØî | | Log├¡stica     | Ô£à | ÔØî | ÔØî | Ô£à | Ô£à | ÔØî | ÔØî | | Finanzas      | Ô£à | ÔØî | ÔØî | ÔØî | ÔØî | Ô£à | Ô£à | | Configuraci├│n | Ô£à | ÔØî | ÔØî | ÔØî | ÔØî | ÔØî | ÔØî |  ## Test plan - [ ] Login ÔåÆ redirige a `/inicio` - [ ] Role `seller`: ve Inicio, Ventas, Clientes, Cat├ílogo ÔÇö NO ve Log├¡stica, Finanzas, Configuraci├│n - [ ] Role `driver`: ve solo Inicio y Log├¡stica - [ ] Role `owner`: ve las 7 secciones - [ ] `npm run type-check` Ô£à - [ ] `npm run lint` Ô£à - [ ] `npm run check:i18n` Ô£à  Closes #28  ­ƒñû Generated with [Claude Code](https://claude.com/claude-code)

Closes #28