### PR TITLE
feat(dashboard): página de inicio con KPIs del día

### DIFF
--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -9,6 +9,7 @@ import { parse as parseYaml } from 'yaml'
 import swaggerUi from 'swagger-ui-express'
 import { registerAuthRoutes, requirePermission, resolveSession, type AuthenticatedRequest } from './auth'
 import { registerUserRoutes } from './users'
+import { registerDashboardRoutes } from './dashboard'
 
 const DEFAULT_CORS_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'] as const
 
@@ -83,6 +84,7 @@ export function createApp(prisma: PrismaClient): Application {
 
   registerAuthRoutes(app, prisma)
   registerUserRoutes(app, prisma)
+  registerDashboardRoutes(app, prisma)
 
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(getOpenApiDocument()))
 

--- a/server/dashboard.ts
+++ b/server/dashboard.ts
@@ -1,0 +1,89 @@
+import type { Application, Request, Response } from 'express'
+import type { PrismaClient } from '@prisma/client'
+import { type AuthenticatedRequest } from './auth'
+
+/**
+ * @en Dashboard summary shape returned by GET /api/dashboard/summary.
+ * @es Forma del resumen del dashboard retornado por GET /api/dashboard/summary.
+ * @pt-BR Formato do resumo do dashboard retornado por GET /api/dashboard/summary.
+ */
+export type DashboardSummary = {
+  /** Invoices issued today (estado = "A"). */
+  ventasHoy: { count: number; total: string }
+  /**
+   * Overdue invoices: active invoices whose fecha < (today – 30 days).
+   * Approximation until credit-term fields are available (Issue #31).
+   */
+  facturasVencidas: { count: number; total: string }
+  /** Pending collections — placeholder until payment model is ready (Issue #31). */
+  cobrosHoy: { count: number; total: string }
+  /** Active unread alerts — placeholder until Notification model is ready (Issue #30). */
+  alertasActivas: number
+}
+
+/**
+ * @en Registers the dashboard summary route: GET /api/dashboard/summary.
+ *     Accessible to all authenticated users (no specific permission required).
+ *     Role-aware seller filtering deferred to Issue #31 (vendedorId field).
+ * @es Registra la ruta del resumen del dashboard: GET /api/dashboard/summary.
+ *     Accesible para todos los usuarios autenticados (sin permiso específico requerido).
+ *     Filtro por vendedor diferido al Issue #31 (campo vendedorId).
+ * @pt-BR Registra a rota do resumo do dashboard: GET /api/dashboard/summary.
+ *     Acessível a todos os usuários autenticados (sem permissão específica necessária).
+ *     Filtro por vendedor adiado para a Issue #31 (campo vendedorId).
+ */
+export function registerDashboardRoutes(app: Application, prisma: PrismaClient): void {
+  app.get('/api/dashboard/summary', async (req: Request, res: Response) => {
+    const authReq = req as AuthenticatedRequest
+    if (!authReq.auth) {
+      res.status(401).json({ success: false, error: 'Authentication required' })
+      return
+    }
+
+    try {
+      const now = new Date()
+      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0)
+      const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999)
+
+      // 30-day threshold for overdue approximation (real credit-term calculation in Issue #31)
+      const thirtyDaysAgo = new Date(now)
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      const [ventasResult, vencidasResult] = await Promise.all([
+        // Active invoices created today
+        prisma.factura.aggregate({
+          where: { estado: 'A', fecha: { gte: todayStart, lte: todayEnd } },
+          _count: { id: true },
+          _sum: { total: true },
+        }),
+        // Active invoices older than 30 days (overdue approximation)
+        prisma.factura.aggregate({
+          where: { estado: 'A', fecha: { lt: thirtyDaysAgo } },
+          _count: { id: true },
+          _sum: { total: true },
+        }),
+      ])
+
+      const summary: DashboardSummary = {
+        ventasHoy: {
+          count: ventasResult._count.id,
+          total: ventasResult._sum.total?.toString() ?? '0',
+        },
+        facturasVencidas: {
+          count: vencidasResult._count.id,
+          total: vencidasResult._sum.total?.toString() ?? '0',
+        },
+        // Placeholders — implemented in Issues #30 (notifications) and #31 (payments)
+        cobrosHoy: { count: 0, total: '0' },
+        alertasActivas: 0,
+      }
+
+      res.json({ success: true, data: summary })
+    } catch (err: unknown) {
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -338,6 +338,30 @@ export const usersAPI = {
   },
 }
 
+// ============ DASHBOARD ============
+
+export type DashboardWidget = { count: number; total: string }
+
+export type DashboardSummaryDTO = {
+  ventasHoy: DashboardWidget
+  facturasVencidas: DashboardWidget
+  cobrosHoy: DashboardWidget
+  alertasActivas: number
+}
+
+export const dashboardAPI = {
+  summary: async (): Promise<DashboardSummaryDTO> => {
+    try {
+      const response = await api.get<{ success: boolean; data: DashboardSummaryDTO }>(
+        '/dashboard/summary',
+      )
+      return response.data.data
+    } catch (error) {
+      return handleError(error as AxiosError<ApiErrorPayload>)
+    }
+  },
+}
+
 // ============ HEALTH CHECK ============
 
 export const checkAPI = async () => {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -86,5 +86,17 @@
   "errors": {
     "generic": "Error saving",
     "required": "Required field"
+  },
+  "dashboard": {
+    "title": "Today's summary",
+    "ventasHoy": "Today's sales",
+    "facturasVencidas": "Overdue invoices",
+    "cobrosHoy": "Today's collections",
+    "alertasActivas": "Active alerts",
+    "invoices": "{{count}} invoice",
+    "invoices_other": "{{count}} invoices",
+    "noData": "No data",
+    "overdueNote": "Estimated — real credit terms available in next version",
+    "pendingFeature": "Available in v0.2.0"
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -86,5 +86,17 @@
   "errors": {
     "generic": "Error al guardar",
     "required": "Campo requerido"
+  },
+  "dashboard": {
+    "title": "Resumen del día",
+    "ventasHoy": "Ventas del día",
+    "facturasVencidas": "Facturas vencidas",
+    "cobrosHoy": "Cobros del día",
+    "alertasActivas": "Alertas activas",
+    "invoices": "{{count}} factura",
+    "invoices_other": "{{count}} facturas",
+    "noData": "Sin datos",
+    "overdueNote": "Estimado — plazos reales disponibles en próxima versión",
+    "pendingFeature": "Disponible en v0.2.0"
   }
 }

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -86,5 +86,17 @@
   "errors": {
     "generic": "Erro ao salvar",
     "required": "Campo obrigatório"
+  },
+  "dashboard": {
+    "title": "Resumo do dia",
+    "ventasHoy": "Vendas de hoje",
+    "facturasVencidas": "Faturas vencidas",
+    "cobrosHoy": "Cobranças de hoje",
+    "alertasActivas": "Alertas ativos",
+    "invoices": "{{count}} fatura",
+    "invoices_other": "{{count}} faturas",
+    "noData": "Sem dados",
+    "overdueNote": "Estimado — prazos reais disponíveis na próxima versão",
+    "pendingFeature": "Disponível em v0.2.0"
   }
 }

--- a/src/pages/inicio/index.tsx
+++ b/src/pages/inicio/index.tsx
@@ -1,21 +1,170 @@
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { dashboardAPI, type DashboardSummaryDTO } from '@/lib/api'
 
-/**
- * @en Home / dashboard placeholder — replaced by the real KPI dashboard in Issue #29.
- * @es Página de inicio — placeholder reemplazado por el dashboard real en Issue #29.
- * @pt-BR Página inicial — placeholder substituído pelo dashboard real na Issue #29.
- */
-export default function InicioPage() {
+// ─── KPI Card ────────────────────────────────────────────────────────────────
+
+type KpiCardProps = {
+  title: string
+  count: number
+  total?: string
+  icon: string
+  color: 'blue' | 'red' | 'green' | 'yellow'
+  note?: string
+  pending?: boolean
+}
+
+function KpiCard({ title, count, total, icon, color, note, pending }: KpiCardProps) {
+  const { t, i18n } = useTranslation('common')
+
+  const colorMap = {
+    blue:   'border-blue-500  bg-blue-50  dark:bg-blue-950  text-blue-700  dark:text-blue-300',
+    red:    'border-red-500   bg-red-50   dark:bg-red-950   text-red-700   dark:text-red-300',
+    green:  'border-green-500 bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300',
+    yellow: 'border-yellow-500 bg-yellow-50 dark:bg-yellow-950 text-yellow-700 dark:text-yellow-300',
+  }
+
+  const formatMoney = (value: string) => {
+    const num = parseFloat(value)
+    if (isNaN(num)) return t('dashboard.noData')
+    return new Intl.NumberFormat(i18n.language === 'pt-BR' ? 'pt-BR' : i18n.language === 'en' ? 'en-US' : 'es-AR', {
+      style: 'currency',
+      currency: 'ARS',
+      minimumFractionDigits: 2,
+    }).format(num)
+  }
+
+  return (
+    <div className={`rounded-lg border-l-4 p-5 shadow-sm ${colorMap[color]}`}>
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide opacity-70">{title}</p>
+          {pending ? (
+            <p className="mt-2 text-sm opacity-60">{t('dashboard.pendingFeature')}</p>
+          ) : (
+            <>
+              <p className="mt-1 text-3xl font-bold">
+                {t('dashboard.invoices', { count, defaultValue_other: t('dashboard.invoices_other', { count }) })}
+              </p>
+              {total !== undefined && (
+                <p className="mt-1 text-lg font-semibold">{formatMoney(total)}</p>
+              )}
+            </>
+          )}
+          {note && !pending && (
+            <p className="mt-2 text-xs opacity-50 italic">{note}</p>
+          )}
+        </div>
+        <span className="text-3xl" aria-hidden="true">{icon}</span>
+      </div>
+    </div>
+  )
+}
+
+// ─── Alert Card for alertasActivas ──────────────────────────────────────────
+
+function AlertCard({ count, pending }: { count: number; pending: boolean }) {
   const { t } = useTranslation('common')
 
   return (
+    <div className="rounded-lg border-l-4 border-orange-500 bg-orange-50 dark:bg-orange-950 text-orange-700 dark:text-orange-300 p-5 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide opacity-70">
+            {t('dashboard.alertasActivas')}
+          </p>
+          {pending ? (
+            <p className="mt-2 text-sm opacity-60">{t('dashboard.pendingFeature')}</p>
+          ) : (
+            <p className="mt-1 text-3xl font-bold">{count}</p>
+          )}
+        </div>
+        <span className="text-3xl" aria-hidden="true">🔔</span>
+      </div>
+    </div>
+  )
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+/**
+ * @en Dashboard home page — displays today's KPIs from GET /api/dashboard/summary.
+ * @es Página de inicio — muestra los KPIs del día de GET /api/dashboard/summary.
+ * @pt-BR Página inicial — exibe os KPIs do dia de GET /api/dashboard/summary.
+ */
+export default function InicioPage() {
+  const { t } = useTranslation('common')
+  const [data, setData] = useState<DashboardSummaryDTO | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    dashboardAPI
+      .summary()
+      .then((summary) => {
+        if (!cancelled) {
+          setData(summary)
+          setLoading(false)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err))
+          setLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
     <div className="p-8">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
-        {t('nav.inicio')}
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6">
+        {t('dashboard.title')}
       </h1>
-      <p className="text-slate-500 dark:text-slate-400 text-sm">
-        {t('status.comingSoon')}
-      </p>
+
+      {loading && (
+        <p className="text-slate-500 dark:text-slate-400" role="status" aria-busy="true">
+          {t('status.loading')}
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="text-red-600 dark:text-red-400 text-sm">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && data && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-5">
+          <KpiCard
+            title={t('dashboard.ventasHoy')}
+            count={data.ventasHoy.count}
+            total={data.ventasHoy.total}
+            icon="💰"
+            color="blue"
+          />
+          <KpiCard
+            title={t('dashboard.facturasVencidas')}
+            count={data.facturasVencidas.count}
+            total={data.facturasVencidas.total}
+            icon="⚠️"
+            color="red"
+            note={t('dashboard.overdueNote')}
+          />
+          <KpiCard
+            title={t('dashboard.cobrosHoy')}
+            count={data.cobrosHoy.count}
+            total={data.cobrosHoy.total}
+            icon="💳"
+            color="green"
+            pending={true}
+          />
+          <AlertCard count={data.alertasActivas} pending={data.alertasActivas === 0} />
+        </div>
+      )}
     </div>
   )
 }

--- a/tests/api/dashboard.test.ts
+++ b/tests/api/dashboard.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import type { PrismaClient } from '@prisma/client'
+import { createApp } from '../../server/createApp'
+
+/** Aggregate result shape returned by prisma.factura.aggregate */
+type AggregateResult = { _count: { id: number }; _sum: { total: string | null } }
+
+const EMPTY_AGGREGATE: AggregateResult = { _count: { id: 0 }, _sum: { total: null } }
+const FILLED_AGGREGATE: AggregateResult = { _count: { id: 3 }, _sum: { total: '150000.00' } }
+
+function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  return {
+    cliente: { findMany: vi.fn().mockResolvedValue([]) },
+    articulo: { findMany: vi.fn().mockResolvedValue([]) },
+    rubro: { findMany: vi.fn().mockResolvedValue([]) },
+    formaPago: { findMany: vi.fn().mockResolvedValue([]) },
+    factura: {
+      findMany: vi.fn().mockResolvedValue([]),
+      aggregate: vi.fn().mockResolvedValue(EMPTY_AGGREGATE),
+    },
+    auditEvent: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+    appUser: {
+      count: vi.fn().mockResolvedValue(1),
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+    },
+    tenant: {
+      findUnique: vi.fn().mockResolvedValue({ id: 1, slug: 'demo', active: true }),
+    },
+    appSession: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(buildPrismaMock())
+      return arg
+    }),
+    ...overrides,
+  } as unknown as PrismaClient
+}
+
+describe('GET /api/dashboard/summary', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+  })
+
+  it('returns 401 without session', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'false'
+    delete process.env.BIZCODE_TEST_ROLE
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/dashboard/summary').expect(401)
+    expect(res.body).toEqual({ success: false, error: 'Authentication required' })
+  })
+
+  it('returns summary for authenticated owner', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.success).toBe(true)
+    const d = res.body.data
+    expect(d).toHaveProperty('ventasHoy')
+    expect(d).toHaveProperty('facturasVencidas')
+    expect(d).toHaveProperty('cobrosHoy')
+    expect(d).toHaveProperty('alertasActivas')
+  })
+
+  it('returns summary for authenticated seller', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.success).toBe(true)
+  })
+
+  it('returns summary for authenticated driver', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'driver'
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.success).toBe(true)
+  })
+
+  it('ventasHoy reflects aggregate results', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const prisma = buildPrismaMock()
+    ;(prisma.factura.aggregate as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(FILLED_AGGREGATE)  // ventasHoy
+      .mockResolvedValueOnce(EMPTY_AGGREGATE)   // facturasVencidas
+    const app = createApp(prisma)
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.data.ventasHoy.count).toBe(3)
+    expect(res.body.data.ventasHoy.total).toBe('150000.00')
+  })
+
+  it('facturasVencidas reflects aggregate results', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const prisma = buildPrismaMock()
+    ;(prisma.factura.aggregate as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(EMPTY_AGGREGATE)   // ventasHoy
+      .mockResolvedValueOnce(FILLED_AGGREGATE)  // facturasVencidas
+    const app = createApp(prisma)
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.data.facturasVencidas.count).toBe(3)
+    expect(res.body.data.facturasVencidas.total).toBe('150000.00')
+  })
+
+  it('cobrosHoy and alertasActivas are placeholder zeros', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/dashboard/summary').expect(200)
+    expect(res.body.data.cobrosHoy).toEqual({ count: 0, total: '0' })
+    expect(res.body.data.alertasActivas).toBe(0)
+  })
+
+  it('returns 500 on database error', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const prisma = buildPrismaMock()
+    ;(prisma.factura.aggregate as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('DB connection lost'),
+    )
+    const app = createApp(prisma)
+    const res = await request(app).get('/api/dashboard/summary').expect(500)
+    expect(res.body.success).toBe(false)
+    expect(res.body.error).toContain('DB connection lost')
+  })
+
+  it('calls factura.aggregate twice (ventasHoy + facturasVencidas)', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    await request(app).get('/api/dashboard/summary').expect(200)
+    expect(prisma.factura.aggregate).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Resumen - `GET /api/dashboard/summary` accesible a **todos los roles autenticados** (no requiere permiso espec├¡fico) - P├ígina `/inicio` reemplaza el placeholder con 4 tarjetas KPI en grid responsive - 9 tests de API (401, 200 multi-rol, shape, aggregate ├ù2, error 500) - i18n completo EN/ES/PT-BR  ## KPIs del dashboard | Widget | Fuente | Estado | |--------|--------|--------| | ­ƒÆ░ Ventas del d├¡a | `factura.aggregate` (fecha hoy, estado=A) | Ô£à Real | | ÔÜá´©Å Facturas vencidas | `factura.aggregate` (fecha < hoy-30d, estado=A) | ÔÜá´©Å Aprox. ÔÇö plazos reales en Issue #31 | | ­ƒÆ│ Cobros del d├¡a | ÔÇö | ­ƒö£ Placeholder ÔÇö Issue #31 | | ­ƒöö Alertas activas | ÔÇö | ­ƒö£ Placeholder ÔÇö Issue #30 |  ## Notas t├®cnicas - La aprobaci├│n por vendedor (`vendedorId` en Factura) queda para Issue #31 ÔÇö el modelo legacy no tiene este campo a├║n - Sin tenantId en Factura/Cliente (dise├▒o legacy): todos los usuarios ven los mismos datos hasta que se a├▒ada la migraci├│n  ## Test plan - [ ] Login ÔåÆ muestra 4 tarjetas en `/inicio` - [ ] Sin conexi├│n al API ÔåÆ muestra mensaje de error - [ ] Todos los roles ven la p├ígina (seller, driver, owner) - [ ] `npm run type-check` Ô£à - [ ] `npm run lint` Ô£à - [ ] `npm run check:i18n` Ô£à - [ ] `npx vitest run tests/api/dashboard.test.ts` ÔåÆ 9/9 Ô£à  Closes #29 Base: feature/nav-restructure (se mergea a develop junto con PR #37)  ­ƒñû Generated with [Claude Code](https://claude.com/claude-code)

Closes #29