### PR TITLE
feat(clientes): perfil completo con estado de cuenta y scoring

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -741,6 +741,36 @@ components:
           nullable: true
         activo:
           type: boolean
+        creditLimit:
+          type: number
+          nullable: true
+          description: Credit limit in ARS. null = no limit.
+        creditDays:
+          type: integer
+          default: 0
+          description: Usual credit days for this customer.
+        balance:
+          type: number
+          default: 0
+          description: Accumulated balance (incremented on each new factura).
+        balanceInicial:
+          type: number
+          default: 0
+          description: Opening balance at migration time.
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+          default: 50
+          description: Payment score 0-100 (50=neutral, 0=high risk, 100=perfect).
+        suspended:
+          type: boolean
+          default: false
+          description: When true, POST /api/facturas returns 422 CLIENT_SUSPENDED.
+        deliveryZoneId:
+          type: integer
+          nullable: true
+          description: FK to DeliveryZone (deferred — Issue #32).
 
     ClienteInput:
       type: object
@@ -777,6 +807,14 @@ components:
           type: string
           format: email
         activo:
+          type: boolean
+        creditLimit:
+          type: number
+          nullable: true
+        creditDays:
+          type: integer
+          minimum: 0
+        suspended:
           type: boolean
 
     ClienteListEnvelope:

--- a/prisma/migrations/20260415195721_add_cliente_financials/migration.sql
+++ b/prisma/migrations/20260415195721_add_cliente_financials/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Cliente" ADD COLUMN     "balance" DECIMAL(14,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "balanceInicial" DECIMAL(14,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "creditDays" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "creditLimit" DECIMAL(14,2),
+ADD COLUMN     "deliveryZoneId" INTEGER,
+ADD COLUMN     "score" INTEGER NOT NULL DEFAULT 50,
+ADD COLUMN     "suspended" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,21 +28,30 @@ enum UserRole {
 }
 
 model Cliente {
-  id        Int       @id @default(autoincrement())
-  codigo    Int       @unique
-  rsocial   String    @db.VarChar(30)
-  fantasia  String?   @db.VarChar(30)
-  cuit      String?   @db.VarChar(14)
-  condIva   String    @db.VarChar(1) // RI, Mono, CF, Exento
-  domicilio String?   @db.VarChar(40)
-  localidad String?   @db.VarChar(25)
-  cpost     String?   @db.VarChar(8)
-  telef     String?   @db.VarChar(25)
-  email     String?   @db.VarChar(50)
-  formaPago Int?      // FK a FormaPago.id
-  activo    Boolean   @default(true)
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  id             Int      @id @default(autoincrement())
+  codigo         Int      @unique
+  rsocial        String   @db.VarChar(30)
+  fantasia       String?  @db.VarChar(30)
+  cuit           String?  @db.VarChar(14)
+  condIva        String   @db.VarChar(1) // RI, Mono, CF, Exento
+  domicilio      String?  @db.VarChar(40)
+  localidad      String?  @db.VarChar(25)
+  cpost          String?  @db.VarChar(8)
+  telef          String?  @db.VarChar(25)
+  email          String?  @db.VarChar(50)
+  formaPago      Int?     // FK a FormaPago.id
+  activo         Boolean  @default(true)
+  // ── Financial fields (Issue #31) ──────────────────────────────────────────
+  creditLimit    Decimal? @db.Decimal(14, 2)         // null = sin límite
+  creditDays     Int      @default(0)                 // días de plazo habituales
+  balance        Decimal  @db.Decimal(14, 2) @default(0)  // saldo acumulado
+  balanceInicial Decimal  @db.Decimal(14, 2) @default(0)  // saldo al migrar datos
+  score          Int      @default(50)               // score de pago 0-100
+  suspended      Boolean  @default(false)            // bloquea nuevas ventas
+  deliveryZoneId Int?     // FK diferida — relación en Issue #32
+  // ──────────────────────────────────────────────────────────────────────────
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   facturas Factura[]
 }

--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -10,7 +10,7 @@ import swaggerUi from 'swagger-ui-express'
 import { registerAuthRoutes, requirePermission, resolveSession, type AuthenticatedRequest } from './auth'
 import { registerUserRoutes } from './users'
 import { registerDashboardRoutes } from './dashboard'
-import { registerNotificationRoutes } from './notifications'
+import { registerNotificationRoutes, notifyManagers } from './notifications'
 
 const DEFAULT_CORS_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'] as const
 
@@ -158,11 +158,21 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/clientes/:id', requirePermission('customers.manage'), async (req: Request, res: Response) => {
     try {
+      const authReq = req as AuthenticatedRequest
+      const role = authReq.auth?.claims.role
+      const canManageFinancials = role === 'owner' || role === 'manager'
+
+      // Strip financial management fields for roles without the right
+      const { creditLimit, creditDays, suspended, ...baseBody } = req.body as Record<string, unknown>
+      const data = canManageFinancials
+        ? { ...baseBody, creditLimit, creditDays, suspended }
+        : baseBody
+
       const cliente = await prisma.cliente.update({
         where: { id: parseInt(String(req.params.id), 10) },
-        data: req.body,
+        data,
       })
-      await writeAudit(req as AuthenticatedRequest, 'cliente_update', 'cliente', String(cliente.id))
+      await writeAudit(authReq, 'cliente_update', 'cliente', String(cliente.id))
       res.json({ success: true, data: cliente })
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
@@ -283,15 +293,51 @@ export function createApp(prisma: PrismaClient): Application {
         string,
         unknown
       >
-      const result = await prisma.factura.create({
-        data: {
-          ...factura,
-          items: {
-            create: items,
-          },
-        } as Parameters<typeof prisma.factura.create>[0]['data'],
-        include: { items: true },
+      const clienteId = parseInt(String(factura.clienteId), 10)
+
+      // Check suspension before creating the factura
+      const clienteCheck = await prisma.cliente.findUnique({
+        where: { id: clienteId },
+        select: { suspended: true },
       })
+      if (clienteCheck?.suspended) {
+        res.status(422).json({ success: false, error: 'CLIENT_SUSPENDED' })
+        return
+      }
+
+      // Create factura and update customer balance atomically
+      const [result, updatedCliente] = await prisma.$transaction(async (tx) => {
+        const newFactura = await tx.factura.create({
+          data: {
+            ...factura,
+            items: { create: items },
+          } as Parameters<typeof prisma.factura.create>[0]['data'],
+          include: { items: true },
+        })
+
+        const updated = await tx.cliente.update({
+          where: { id: clienteId },
+          data: { balance: { increment: newFactura.total } },
+          select: { id: true, rsocial: true, balance: true, creditLimit: true },
+        })
+
+        return [newFactura, updated] as const
+      })
+
+      // Notify managers if balance exceeds credit limit (non-blocking)
+      if (
+        updatedCliente.creditLimit !== null &&
+        Number(updatedCliente.balance) > Number(updatedCliente.creditLimit)
+      ) {
+        const authReq = req as AuthenticatedRequest
+        notifyManagers(prisma, authReq.auth!.claims.tenantId, 'credit_limit_exceeded', {
+          clienteId: updatedCliente.id,
+          rsocial: updatedCliente.rsocial,
+          amount: String(updatedCliente.balance),
+          limit: String(updatedCliente.creditLimit),
+        }).catch(() => { /* notification failure must not block the sale */ })
+      }
+
       await writeAudit(req as AuthenticatedRequest, 'factura_create', 'factura', String(result.id))
       res.json({ success: true, data: result })
     } catch (err: unknown) {

--- a/src/locales/en/clientes.json
+++ b/src/locales/en/clientes.json
@@ -37,6 +37,22 @@
       "cuit": "Invalid Tax ID",
       "rsocial": "Company name must be at least 3 characters",
       "generic": "Error saving customer"
+    },
+    "financial": {
+      "section": "Financial status",
+      "creditLimit": "Credit limit",
+      "creditLimitHint": "Empty = no limit",
+      "creditDays": "Credit days",
+      "balance": "Accumulated balance",
+      "balanceInicial": "Opening balance",
+      "score": "Payment score",
+      "suspended": "Suspended (blocks new sales)",
+      "scoreLabel": "Score",
+      "scoreLow": "High risk",
+      "scoreMid": "Medium risk",
+      "scoreHigh": "Good payer",
+      "suspendedBadge": "SUSPENDED",
+      "readOnly": "Read-only — your role cannot modify financial data"
     }
   }
 }

--- a/src/locales/es/clientes.json
+++ b/src/locales/es/clientes.json
@@ -37,6 +37,22 @@
       "cuit": "CUIT inválido",
       "rsocial": "Razón social mínimo 3 caracteres",
       "generic": "Error al guardar cliente"
+    },
+    "financial": {
+      "section": "Estado financiero",
+      "creditLimit": "Límite de crédito",
+      "creditLimitHint": "Vacío = sin límite",
+      "creditDays": "Días de plazo",
+      "balance": "Saldo acumulado",
+      "balanceInicial": "Saldo inicial",
+      "score": "Score de pago",
+      "suspended": "Suspendido (bloquea nuevas ventas)",
+      "scoreLabel": "Score",
+      "scoreLow": "Riesgo alto",
+      "scoreMid": "Riesgo medio",
+      "scoreHigh": "Buen pagador",
+      "suspendedBadge": "SUSPENDIDO",
+      "readOnly": "Solo lectura — tu rol no puede modificar datos financieros"
     }
   }
 }

--- a/src/locales/pt-BR/clientes.json
+++ b/src/locales/pt-BR/clientes.json
@@ -37,6 +37,22 @@
       "cuit": "CNPJ/CPF inválido",
       "rsocial": "Razão social deve ter pelo menos 3 caracteres",
       "generic": "Erro ao salvar cliente"
+    },
+    "financial": {
+      "section": "Situação financeira",
+      "creditLimit": "Limite de crédito",
+      "creditLimitHint": "Vazio = sem limite",
+      "creditDays": "Dias de prazo",
+      "balance": "Saldo acumulado",
+      "balanceInicial": "Saldo inicial",
+      "score": "Score de pagamento",
+      "suspended": "Suspenso (bloqueia novas vendas)",
+      "scoreLabel": "Score",
+      "scoreLow": "Alto risco",
+      "scoreMid": "Risco médio",
+      "scoreHigh": "Bom pagador",
+      "suspendedBadge": "SUSPENSO",
+      "readOnly": "Somente leitura — seu perfil não pode modificar dados financeiros"
     }
   }
 }

--- a/src/pages/clientes/ClienteForm.tsx
+++ b/src/pages/clientes/ClienteForm.tsx
@@ -6,6 +6,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useTranslation } from 'react-i18next'
 import { clientesAPI } from '@/lib/api'
 import { validateCUIT, formatCUIT } from '@/lib/validators'
+import { useAuth } from '@/contexts/AuthContext'
 import { Cliente } from '@/types'
 
 const clienteSchema = z.object({
@@ -23,6 +24,10 @@ const clienteSchema = z.object({
   telef: z.string().max(25).optional(),
   email: z.string().email('Email inválido').max(50).optional().or(z.literal('')),
   activo: z.boolean(),
+  // Financial fields — only sent when the user has manager/owner role
+  creditLimit: z.coerce.number().positive().optional().nullable(),
+  creditDays: z.coerce.number().int().min(0).optional(),
+  suspended: z.boolean().optional(),
 })
 
 type ClienteFormData = z.infer<typeof clienteSchema>
@@ -36,6 +41,8 @@ interface ClienteFormProps {
 export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFormProps) {
   const { t } = useTranslation('clientes')
   const { t: tc } = useTranslation('common')
+  const { claims } = useAuth()
+  const canManageFinancials = claims?.role === 'owner' || claims?.role === 'manager'
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -66,6 +73,9 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
       setValue('telef', cliente.telef)
       setValue('email', cliente.email)
       setValue('activo', cliente.activo)
+      setValue('creditLimit', cliente.creditLimit != null ? Number(cliente.creditLimit) : null)
+      setValue('creditDays', cliente.creditDays ?? 0)
+      setValue('suspended', cliente.suspended ?? false)
     }
   }, [cliente, setValue])
 
@@ -291,6 +301,124 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
               {t('form.activo')}
             </label>
           </div>
+
+          {/* ── Financial section ─────────────────────────────────────────── */}
+          {cliente && (
+            <div className="border border-slate-200 dark:border-slate-600 rounded-lg p-4 space-y-4 mt-2">
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold text-slate-700 dark:text-slate-300">
+                  {t('form.financial.section')}
+                </h3>
+                {/* Score badge */}
+                {cliente.score != null && (
+                  <span
+                    className={`text-xs font-bold px-2 py-1 rounded-full ${
+                      (cliente.score ?? 50) >= 71
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        : (cliente.score ?? 50) >= 41
+                          ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                          : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                    }`}
+                  >
+                    {t('form.financial.scoreLabel')}: {cliente.score}{' '}
+                    {(cliente.score ?? 50) >= 71
+                      ? `— ${t('form.financial.scoreHigh')}`
+                      : (cliente.score ?? 50) >= 41
+                        ? `— ${t('form.financial.scoreMid')}`
+                        : `— ${t('form.financial.scoreLow')}`}
+                  </span>
+                )}
+                {/* Suspended badge */}
+                {cliente.suspended && (
+                  <span className="text-xs font-bold px-2 py-1 rounded-full bg-red-600 text-white">
+                    {t('form.financial.suspendedBadge')}
+                  </span>
+                )}
+              </div>
+
+              {/* Balance display (read-only for all) */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">{t('form.financial.balance')}</p>
+                  <p className="font-mono text-slate-900 dark:text-slate-100">
+                    {Number(cliente.balance ?? 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS' })}
+                  </p>
+                </div>
+                {cliente.creditLimit != null && (
+                  <div>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">{t('form.financial.creditLimit')}</p>
+                    <p className="font-mono text-slate-900 dark:text-slate-100">
+                      {Number(cliente.creditLimit).toLocaleString('es-AR', { style: 'currency', currency: 'ARS' })}
+                    </p>
+                    {/* Credit usage bar */}
+                    {cliente.creditLimit != null && Number(cliente.creditLimit) > 0 && (
+                      <div className="mt-1 h-2 rounded-full bg-slate-200 dark:bg-slate-600 overflow-hidden">
+                        <div
+                          className={`h-2 rounded-full transition-all ${
+                            Number(cliente.balance) > Number(cliente.creditLimit)
+                              ? 'bg-red-500'
+                              : Number(cliente.balance) / Number(cliente.creditLimit) > 0.8
+                                ? 'bg-yellow-500'
+                                : 'bg-green-500'
+                          }`}
+                          style={{
+                            width: `${Math.min(100, (Number(cliente.balance) / Number(cliente.creditLimit)) * 100)}%`,
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Editable financial fields — manager/owner only */}
+              {canManageFinancials ? (
+                <div className="space-y-3 pt-2 border-t border-slate-200 dark:border-slate-600">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label htmlFor="cliente-creditLimit" className="block text-slate-700 dark:text-slate-300 font-semibold mb-1 text-sm">
+                        {t('form.financial.creditLimit')}
+                        <span className="ml-1 text-xs text-slate-400">({t('form.financial.creditLimitHint')})</span>
+                      </label>
+                      <input
+                        id="cliente-creditLimit"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        {...register('creditLimit')}
+                        className="w-full px-3 py-2 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded border border-slate-300 dark:border-slate-600 focus:border-blue-500 focus:outline-none font-mono"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="cliente-creditDays" className="block text-slate-700 dark:text-slate-300 font-semibold mb-1 text-sm">
+                        {t('form.financial.creditDays')}
+                      </label>
+                      <input
+                        id="cliente-creditDays"
+                        type="number"
+                        min="0"
+                        {...register('creditDays')}
+                        className="w-full px-3 py-2 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded border border-slate-300 dark:border-slate-600 focus:border-blue-500 focus:outline-none"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <input
+                      id="cliente-suspended"
+                      type="checkbox"
+                      {...register('suspended')}
+                      className="w-4 h-4 rounded bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 cursor-pointer accent-red-600"
+                    />
+                    <label htmlFor="cliente-suspended" className="text-slate-700 dark:text-slate-300 font-semibold cursor-pointer text-sm">
+                      {t('form.financial.suspended')}
+                    </label>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-slate-400 italic">{t('form.financial.readOnly')}</p>
+              )}
+            </div>
+          )}
 
           <div className="flex gap-3 pt-6 border-t border-slate-200 dark:border-slate-600">
             <button

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,14 @@ export interface Cliente {
   email?: string
   formaPago?: number
   activo: boolean
+  // Financial fields (Issue #31)
+  creditLimit?: number | string | null
+  creditDays?: number
+  balance?: number | string
+  balanceInicial?: number | string
+  score?: number
+  suspended?: boolean
+  deliveryZoneId?: number | null
   createdAt: Date
   updatedAt: Date
 }

--- a/tests/api/clientes.test.ts
+++ b/tests/api/clientes.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import type { PrismaClient } from '@prisma/client'
+import { createApp } from '../../server/createApp'
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+const CLIENTE_BASE = {
+  id: 1,
+  codigo: 1001,
+  rsocial: 'ACME SA',
+  fantasia: null,
+  cuit: '20-12345678-9',
+  condIva: 'RI',
+  domicilio: 'Av. Siempre Viva 742',
+  localidad: 'Springfield',
+  cpost: '5000',
+  telef: '351-555-0100',
+  email: 'acme@example.com',
+  formaPago: null,
+  activo: true,
+  creditLimit: null,
+  creditDays: 0,
+  balance: '0.00',
+  balanceInicial: '0.00',
+  score: 50,
+  suspended: false,
+  deliveryZoneId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const FACTURA_BODY = {
+  fecha: new Date().toISOString(),
+  tipo: 'B',
+  prefijo: '0001',
+  numero: 1,
+  clienteId: 1,
+  neto1: '826.45',
+  neto2: '0',
+  neto3: '0',
+  iva1: '173.55',
+  iva2: '0',
+  total: '1000.00',
+  formaPagoId: null,
+  estado: 'A',
+  items: [{ articuloId: 1, cantidad: 2, precio: '500.00', dscto: '0', subtotal: '1000.00' }],
+}
+
+const FACTURA_RESULT = {
+  id: 99,
+  ...FACTURA_BODY,
+  items: FACTURA_BODY.items.map((i, idx) => ({ id: idx + 1, facturaId: 99, ...i, createdAt: new Date() })),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  return {
+    cliente: {
+      findMany: vi.fn().mockResolvedValue([CLIENTE_BASE]),
+      findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
+      create: vi.fn().mockResolvedValue(CLIENTE_BASE),
+      update: vi.fn().mockResolvedValue(CLIENTE_BASE),
+    },
+    articulo: { findMany: vi.fn().mockResolvedValue([]) },
+    rubro: { findMany: vi.fn().mockResolvedValue([]) },
+    formaPago: { findMany: vi.fn().mockResolvedValue([]) },
+    factura: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue(FACTURA_RESULT),
+      aggregate: vi.fn().mockResolvedValue({ _count: { id: 0 }, _sum: { total: null } }),
+    },
+    notification: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    auditEvent: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+    appUser: {
+      count: vi.fn().mockResolvedValue(1),
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+    },
+    tenant: {
+      findUnique: vi.fn().mockResolvedValue({ id: 1, slug: 'demo', active: true }),
+    },
+    appSession: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') return arg(buildPrismaMock())
+      return arg
+    }),
+    ...overrides,
+  } as unknown as PrismaClient
+}
+
+// ─── POST /api/facturas — suspended block ─────────────────────────────────────
+
+describe('POST /api/facturas — cliente suspended', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+  })
+
+  it('returns 422 CLIENT_SUSPENDED when cliente.suspended is true', async () => {
+    const suspendedCliente = { ...CLIENTE_BASE, suspended: true }
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue(suspendedCliente),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .post('/api/facturas')
+      .send(FACTURA_BODY)
+      .expect(422)
+
+    expect(res.body).toEqual({ success: false, error: 'CLIENT_SUSPENDED' })
+    // factura should NOT have been created
+    expect((prisma.factura.create as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled()
+  })
+
+  it('allows creating factura when cliente is not suspended', async () => {
+    const activeCliente = { ...CLIENTE_BASE, suspended: false, balance: '1000.00', creditLimit: null }
+    const txPrisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue(activeCliente),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ id: 1, rsocial: 'ACME SA', balance: '1000.00', creditLimit: null }),
+      },
+      factura: {
+        findMany: vi.fn().mockResolvedValue([]),
+        create: vi.fn().mockResolvedValue(FACTURA_RESULT),
+        aggregate: vi.fn(),
+      },
+    })
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue(activeCliente),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ id: 1, rsocial: 'ACME SA', balance: '1000.00', creditLimit: null }),
+      },
+      factura: {
+        findMany: vi.fn().mockResolvedValue([]),
+        create: vi.fn().mockResolvedValue(FACTURA_RESULT),
+        aggregate: vi.fn(),
+      },
+      $transaction: vi.fn(async (fn: unknown) => {
+        if (typeof fn === 'function') return fn(txPrisma)
+        return fn
+      }),
+    })
+
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/facturas').send(FACTURA_BODY).expect(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.id).toBe(99)
+  })
+})
+
+// ─── POST /api/facturas — balance update ─────────────────────────────────────
+
+describe('POST /api/facturas — balance update', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+  })
+
+  it('increments cliente balance inside the transaction', async () => {
+    const clienteUpdate = vi.fn().mockResolvedValue({
+      id: 1,
+      rsocial: 'ACME SA',
+      balance: '1000.00',
+      creditLimit: null,
+    })
+    const facturaCreate = vi.fn().mockResolvedValue(FACTURA_RESULT)
+
+    const txPrisma = {
+      cliente: { update: clienteUpdate },
+      factura: { create: facturaCreate },
+    } as unknown as PrismaClient
+
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+      $transaction: vi.fn(async (fn: unknown) => {
+        if (typeof fn === 'function') return fn(txPrisma)
+        return fn
+      }),
+    })
+
+    const app = createApp(prisma)
+    await request(app).post('/api/facturas').send(FACTURA_BODY).expect(200)
+
+    expect(clienteUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: { balance: { increment: expect.anything() } },
+      }),
+    )
+  })
+})
+
+// ─── POST /api/facturas — credit limit notification ───────────────────────────
+
+describe('POST /api/facturas — credit limit notification', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+  })
+
+  it('calls notifyManagers when balance exceeds creditLimit', async () => {
+    // balance (2000) > creditLimit (1500) → notification triggered
+    const updatedCliente = { id: 1, rsocial: 'ACME SA', balance: '2000.00', creditLimit: '1500.00' }
+
+    const clienteUpdate = vi.fn().mockResolvedValue(updatedCliente)
+    const facturaCreate = vi.fn().mockResolvedValue(FACTURA_RESULT)
+    const notifCreateMany = vi.fn().mockResolvedValue({ count: 1 })
+
+    const managers = [{ id: 10 }, { id: 11 }]
+
+    const txPrisma = {
+      cliente: { update: clienteUpdate },
+      factura: { create: facturaCreate },
+    } as unknown as PrismaClient
+
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+      appUser: {
+        count: vi.fn().mockResolvedValue(2),
+        findMany: vi.fn().mockResolvedValue(managers),
+        findFirst: vi.fn().mockResolvedValue(null),
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+      notification: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: 1 }),
+        createMany: notifCreateMany,
+        update: vi.fn().mockResolvedValue(null),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      $transaction: vi.fn(async (fn: unknown) => {
+        if (typeof fn === 'function') return fn(txPrisma)
+        return fn
+      }),
+    })
+
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/facturas').send(FACTURA_BODY).expect(200)
+
+    expect(res.body.success).toBe(true)
+    // Give the non-blocking notifyManagers call time to settle
+    await new Promise((r) => setTimeout(r, 50))
+    expect(notifCreateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ type: 'credit_limit_exceeded', userId: 10 }),
+          expect.objectContaining({ type: 'credit_limit_exceeded', userId: 11 }),
+        ]),
+      }),
+    )
+  })
+
+  it('does NOT notify when balance is under creditLimit', async () => {
+    // balance (500) < creditLimit (1500) → no notification
+    const updatedCliente = { id: 1, rsocial: 'ACME SA', balance: '500.00', creditLimit: '1500.00' }
+
+    const clienteUpdate = vi.fn().mockResolvedValue(updatedCliente)
+    const notifCreateMany = vi.fn().mockResolvedValue({ count: 0 })
+
+    const txPrisma = {
+      cliente: { update: clienteUpdate },
+      factura: { create: vi.fn().mockResolvedValue(FACTURA_RESULT) },
+    } as unknown as PrismaClient
+
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+      notification: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: 1 }),
+        createMany: notifCreateMany,
+        update: vi.fn().mockResolvedValue(null),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      $transaction: vi.fn(async (fn: unknown) => {
+        if (typeof fn === 'function') return fn(txPrisma)
+        return fn
+      }),
+    })
+
+    const app = createApp(prisma)
+    await request(app).post('/api/facturas').send(FACTURA_BODY).expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(notifCreateMany).not.toHaveBeenCalled()
+  })
+
+  it('does NOT notify when creditLimit is null (no limit set)', async () => {
+    const updatedCliente = { id: 1, rsocial: 'ACME SA', balance: '99999.00', creditLimit: null }
+
+    const clienteUpdate = vi.fn().mockResolvedValue(updatedCliente)
+    const notifCreateMany = vi.fn().mockResolvedValue({ count: 0 })
+
+    const txPrisma = {
+      cliente: { update: clienteUpdate },
+      factura: { create: vi.fn().mockResolvedValue(FACTURA_RESULT) },
+    } as unknown as PrismaClient
+
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+      notification: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: 1 }),
+        createMany: notifCreateMany,
+        update: vi.fn().mockResolvedValue(null),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      $transaction: vi.fn(async (fn: unknown) => {
+        if (typeof fn === 'function') return fn(txPrisma)
+        return fn
+      }),
+    })
+
+    const app = createApp(prisma)
+    await request(app).post('/api/facturas').send(FACTURA_BODY).expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(notifCreateMany).not.toHaveBeenCalled()
+  })
+})
+
+// ─── PUT /api/clientes/:id — role-based financial field restriction ───────────
+
+describe('PUT /api/clientes/:id — financial field access', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+  })
+
+  it('manager can update creditLimit and suspended', async () => {
+    process.env.BIZCODE_TEST_ROLE = 'manager'
+    const clienteUpdate = vi.fn().mockResolvedValue({ ...CLIENTE_BASE, creditLimit: '5000.00', suspended: true })
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+    })
+
+    const app = createApp(prisma)
+    const res = await request(app)
+      .put('/api/clientes/1')
+      .send({ rsocial: 'ACME SA', creditLimit: 5000, suspended: true })
+      .expect(200)
+
+    expect(res.body.success).toBe(true)
+    expect(clienteUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ creditLimit: 5000, suspended: true }),
+      }),
+    )
+  })
+
+  it('seller cannot update creditLimit or suspended (fields stripped)', async () => {
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+    const clienteUpdate = vi.fn().mockResolvedValue(CLIENTE_BASE)
+    const prisma = buildPrismaMock({
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
+        create: vi.fn(),
+        update: clienteUpdate,
+      },
+    })
+
+    const app = createApp(prisma)
+    await request(app)
+      .put('/api/clientes/1')
+      .send({ rsocial: 'ACME SA', creditLimit: 5000, suspended: true })
+      .expect(200)
+
+    const callArg = clienteUpdate.mock.calls[0][0] as { data: Record<string, unknown> }
+    expect(callArg.data.creditLimit).toBeUndefined()
+    expect(callArg.data.suspended).toBeUndefined()
+  })
+})

--- a/tests/api/contract.test.ts
+++ b/tests/api/contract.test.ts
@@ -59,12 +59,16 @@ const facturaRow = {
 }
 
 function buildPrisma(): PrismaClient {
-  return {
+  const facturaCreate = vi.fn().mockResolvedValue(facturaRow)
+  // tx-level cliente.update: returns the financial summary the route uses for the credit check
+  const txClienteUpdate = vi.fn().mockResolvedValue({ id: 1, rsocial: 'ACME SA', balance: 121, creditLimit: null })
+
+  const p = {
     cliente: {
       findMany: vi.fn().mockResolvedValue([clienteRow]),
       findUnique: vi.fn().mockResolvedValue(clienteRow),
       create: vi.fn().mockResolvedValue(clienteRow),
-      update: vi.fn().mockResolvedValue(clienteRow),
+      update: vi.fn().mockResolvedValue(clienteRow), // PUT /api/clientes/:id returns full row
     },
     articulo: {
       findMany: vi.fn().mockResolvedValue([articuloRow]),
@@ -81,9 +85,23 @@ function buildPrisma(): PrismaClient {
     },
     factura: {
       findMany: vi.fn().mockResolvedValue([]),
-      create: vi.fn().mockResolvedValue(facturaRow),
+      create: facturaCreate,
+      aggregate: vi.fn().mockResolvedValue({ _count: { id: 0 }, _sum: { total: null } }),
     },
+    // $transaction: shares facturaCreate so mockRejectedValueOnce propagates for 500 tests
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') {
+        const tx = {
+          factura: { create: facturaCreate },
+          cliente: { update: txClienteUpdate },
+        }
+        return arg(tx)
+      }
+      return arg
+    }),
   } as unknown as PrismaClient
+
+  return p
 }
 
 describe('API — contrato OpenAPI', () => {


### PR DESCRIPTION
## Resumen  - Migraci├│n Prisma: 7 campos financieros en `Cliente` (`creditLimit`, `creditDays`, `balance`, `balanceInicial`, `score`, `suspended`, `deliveryZoneId`) - `POST /api/facturas`: bloquea si cliente suspendido (422), actualiza `balance` en transacci├│n, notifica managers si `balance > creditLimit` - `PUT /api/clientes/:id`: restringe campos financieros a owner/manager - Frontend: secci├│n **Estado financiero** en `ClienteForm` ÔÇö score badge, barra de uso del cr├®dito, campos editables por rol - i18n EN/ES/PT-BR completo (`form.financial.*`) - 8 tests nuevos en `tests/api/clientes.test.ts`  ## Test plan  - [x] `npm run type-check` ÔÇö sin errores - [x] `npm run lint` ÔÇö sin warnings - [x] `npx vitest run` ÔÇö 231/231 tests pasando - [ ] Verificar en UI: ficha de cliente con rol manager muestra campos editables - [ ] Verificar en UI: ficha de cliente con rol seller muestra secci├│n en modo lectura - [ ] Crear factura para cliente suspendido ÔåÆ 422 CLIENT_SUSPENDED  Closes #31  ­ƒñû Generated with [Claude Code](https://claude.com/claude-code)

Closes #31