### PR TITLE
feat(comms): canales externos email + WhatsApp para notificaciones (#33)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -535,6 +535,38 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/notifications/channels:
+    get:
+      tags: [notifications]
+      summary: Report which external notification channels are configured
+      description: Returns boolean flags for each channel. No sensitive values are exposed.
+      security:
+        - cookieSession: []
+      responses:
+        '200':
+          description: Channel status
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    required: [inApp, email, whatsapp]
+                    properties:
+                      inApp:
+                        type: boolean
+                      email:
+                        type: boolean
+                      whatsapp:
+                        type: boolean
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
   /api/zonas-entrega:
     get:
       tags: [logistics]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.2",
         "i18next": "^26.0.3",
+        "nodemailer": "^8.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.3",
@@ -24,6 +25,7 @@
         "react-i18next": "^17.0.2",
         "react-router-dom": "^6.22.3",
         "swagger-ui-express": "^5.0.1",
+        "twilio": "^5.13.1",
         "yaml": "^2.8.3",
         "zod": "^3.22.4",
         "zustand": "^4.4.7"
@@ -49,6 +51,7 @@
         "@types/express-rate-limit": "^5.1.3",
         "@types/jest-axe": "^3.5.9",
         "@types/node": "^22.15.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@types/supertest": "^7.2.0",
@@ -4280,6 +4283,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -5767,6 +5780,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6699,6 +6718,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/dbffile": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/dbffile/-/dbffile-1.12.0.tgz",
@@ -7033,6 +7058,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -10917,6 +10951,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10939,6 +10995,27 @@
       "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -11112,18 +11189,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -11131,6 +11230,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
@@ -12878,6 +12983,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "8.1.0",
@@ -17527,7 +17641,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -17603,6 +17716,13 @@
       "dependencies": {
         "extend": "^3.0.0"
       }
+    },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "deprecated": "Just use Node.js's crypto.timingSafeEqual()",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semantic-release": {
       "version": "24.2.9",
@@ -17685,7 +17805,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -19864,6 +19983,49 @@
         "node": "*"
       }
     },
+    "node_modules/twilio": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.13.1.tgz",
+      "integrity": "sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.5",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.3",
+        "qs": "^6.14.1",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/twilio/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/twilio/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -20987,6 +21149,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/xmlbuilder2": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.2",
     "i18next": "^26.0.3",
+    "nodemailer": "^8.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.3",
@@ -73,6 +74,7 @@
     "react-i18next": "^17.0.2",
     "react-router-dom": "^6.22.3",
     "swagger-ui-express": "^5.0.1",
+    "twilio": "^5.13.1",
     "yaml": "^2.8.3",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"
@@ -98,6 +100,7 @@
     "@types/express-rate-limit": "^5.1.3",
     "@types/jest-axe": "^3.5.9",
     "@types/node": "^22.15.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@types/supertest": "^7.2.0",

--- a/server/channels.ts
+++ b/server/channels.ts
@@ -1,0 +1,205 @@
+/**
+ * @en External notification channels (email via nodemailer, WhatsApp via Twilio).
+ *     Configuration is read from environment variables at call time, so tests can
+ *     set / clear them freely.  Every external dispatch is wrapped in try/catch:
+ *     a misconfigured or unavailable channel must NEVER surface an error to the caller.
+ * @es Canales externos de notificaciones (email vía nodemailer, WhatsApp vía Twilio).
+ *     La configuración se lee de variables de entorno en el momento de la llamada.
+ *     Todo dispatch externo está envuelto en try/catch: un canal mal configurado
+ *     o no disponible nunca debe propagar un error al llamador.
+ * @pt-BR Canais externos de notificações (email via nodemailer, WhatsApp via Twilio).
+ *     Configuração lida de variáveis de ambiente no momento da chamada.
+ *     Todo dispatch externo está em try/catch: canal mal configurado nunca deve
+ *     propagar erro ao chamador.
+ */
+
+import nodemailer from 'nodemailer'
+import type { PrismaClient } from '@prisma/client'
+import { notifyManagers } from './notifications'
+import type { NotificationType, NotificationPayload } from './notifications'
+
+// ─── Message templates ────────────────────────────────────────────────────────
+
+type MessageTemplate = { subject: string; text: string }
+
+function buildMessage(type: NotificationType, payload: NotificationPayload): MessageTemplate {
+  const rsocial = payload.rsocial ?? 'Cliente'
+  const amount = payload.amount ? `$${Number(payload.amount).toLocaleString('es-AR')}` : ''
+  const limit = payload.limit ? `$${Number(payload.limit).toLocaleString('es-AR')}` : ''
+
+  switch (type) {
+    case 'credit_limit_exceeded':
+      return {
+        subject: `[BizCode] Límite de crédito superado — ${rsocial}`,
+        text: `El saldo de ${rsocial} (${amount}) superó el límite de crédito configurado (${limit}).`,
+      }
+    case 'invoice_overdue':
+      return {
+        subject: `[BizCode] Factura vencida — ${rsocial}`,
+        text: `Hay una factura vencida de ${rsocial}. Revise el estado de cuenta del cliente.`,
+      }
+    case 'invoice_due_soon':
+      return {
+        subject: `[BizCode] Factura próxima a vencer — ${rsocial}`,
+        text: `Una factura de ${rsocial} está próxima a vencer. Coordine el cobro con anticipación.`,
+      }
+  }
+}
+
+// ─── SMTP helpers ──────────────────────────────────────────────────────────────
+
+export function isSmtpConfigured(): boolean {
+  return Boolean(
+    process.env.SMTP_HOST &&
+      process.env.SMTP_PORT &&
+      process.env.SMTP_USER &&
+      process.env.SMTP_PASS &&
+      process.env.SMTP_FROM,
+  )
+}
+
+/**
+ * @en Sends an email via nodemailer using SMTP env vars.
+ *     Returns silently if SMTP is not configured or the send fails.
+ * @es Envía un email vía nodemailer usando las env vars SMTP.
+ *     Retorna en silencio si SMTP no está configurado o el envío falla.
+ */
+async function sendEmail(
+  to: string[],
+  subject: string,
+  text: string,
+): Promise<void> {
+  if (!isSmtpConfigured() || to.length === 0) return
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST!,
+      port: parseInt(process.env.SMTP_PORT!, 10),
+      secure: parseInt(process.env.SMTP_PORT!, 10) === 465,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    })
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM!,
+      to: to.join(', '),
+      subject,
+      text,
+    })
+  } catch (err) {
+    console.warn('[channels] SMTP send failed:', err instanceof Error ? err.message : String(err))
+  }
+}
+
+// ─── Twilio / WhatsApp helpers ────────────────────────────────────────────────
+
+export function isTwilioConfigured(): boolean {
+  return Boolean(
+    process.env.TWILIO_ACCOUNT_SID &&
+      process.env.TWILIO_AUTH_TOKEN &&
+      process.env.TWILIO_WHATSAPP_FROM,
+  )
+}
+
+/**
+ * @en Sends a WhatsApp message via Twilio.
+ *     Returns silently if Twilio is not configured or the send fails.
+ * @es Envía un mensaje de WhatsApp vía Twilio.
+ *     Retorna en silencio si Twilio no está configurado o el envío falla.
+ */
+async function sendWhatsApp(
+  to: string[],
+  body: string,
+): Promise<void> {
+  if (!isTwilioConfigured() || to.length === 0) return
+  try {
+    // Dynamic import to avoid loading Twilio SDK in environments where it is not needed.
+    const twilio = await import('twilio')
+    const client = twilio.default(
+      process.env.TWILIO_ACCOUNT_SID!,
+      process.env.TWILIO_AUTH_TOKEN!,
+    )
+    await Promise.all(
+      to.map((number) =>
+        client.messages.create({
+          from: `whatsapp:${process.env.TWILIO_WHATSAPP_FROM!}`,
+          to: `whatsapp:${number}`,
+          body,
+        }),
+      ),
+    )
+  } catch (err) {
+    console.warn('[channels] Twilio send failed:', err instanceof Error ? err.message : String(err))
+  }
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @en Dispatches a notification through all configured channels:
+ *     1. In-app (always) — via notifyManagers
+ *     2. Email (if SMTP env vars are set) — to recipients with non-null email
+ *     3. WhatsApp (if Twilio env vars are set) — to recipients with non-null telef
+ *
+ *     External channel failures are logged and swallowed; they must never block
+ *     the calling business operation.
+ *
+ * @es Despacha una notificación por todos los canales configurados:
+ *     1. In-app (siempre) — vía notifyManagers
+ *     2. Email (si hay env vars SMTP) — a destinatarios con email no nulo
+ *     3. WhatsApp (si hay env vars Twilio) — a destinatarios con telef no nulo
+ *
+ * @pt-BR Despacha uma notificação por todos os canais configurados:
+ *     1. In-app (sempre) — via notifyManagers
+ *     2. Email (se env vars SMTP presentes) — para destinatários com email não nulo
+ *     3. WhatsApp (se env vars Twilio presentes) — para destinatários com telef não nulo
+ */
+export async function dispatchNotification(
+  prisma: PrismaClient,
+  tenantId: number,
+  type: NotificationType,
+  payload: NotificationPayload,
+): Promise<void> {
+  // 1. Always send in-app
+  await notifyManagers(prisma, tenantId, type, payload)
+
+  // 2. External channels — only if at least one is configured
+  if (!isSmtpConfigured() && !isTwilioConfigured()) return
+
+  // Fetch manager emails + phones for external channels
+  const managers = await prisma.appUser.findMany({
+    where: {
+      tenantId,
+      active: true,
+      role: { in: ['owner', 'manager'] },
+    },
+    select: { id: true },
+  })
+
+  if (managers.length === 0) return
+
+  // Fetch Cliente details for email/phone if available in payload
+  let emailRecipients: string[] = []
+  let phoneRecipients: string[] = []
+
+  if (payload.clienteId) {
+    try {
+      const cliente = await prisma.cliente.findUnique({
+        where: { id: payload.clienteId },
+        select: { email: true, telef: true },
+      })
+      if (cliente?.email) emailRecipients.push(cliente.email)
+      if (cliente?.telef) phoneRecipients.push(cliente.telef)
+    } catch {
+      // non-critical
+    }
+  }
+
+  const msg = buildMessage(type, payload)
+
+  // 3. Email
+  void sendEmail(emailRecipients, msg.subject, msg.text)
+
+  // 4. WhatsApp
+  void sendWhatsApp(phoneRecipients, `${msg.subject}\n\n${msg.text}`)
+}

--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -10,7 +10,8 @@ import swaggerUi from 'swagger-ui-express'
 import { registerAuthRoutes, requirePermission, resolveSession, type AuthenticatedRequest } from './auth'
 import { registerUserRoutes } from './users'
 import { registerDashboardRoutes } from './dashboard'
-import { registerNotificationRoutes, notifyManagers } from './notifications'
+import { registerNotificationRoutes } from './notifications'
+import { dispatchNotification, isSmtpConfigured, isTwilioConfigured } from './channels'
 
 const DEFAULT_CORS_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'] as const
 
@@ -87,6 +88,28 @@ export function createApp(prisma: PrismaClient): Application {
   registerUserRoutes(app, prisma)
   registerDashboardRoutes(app, prisma)
   registerNotificationRoutes(app, prisma)
+
+  /**
+   * @en Reports which external notification channels are configured (reads env vars server-side).
+   *     No sensitive values are exposed — only boolean flags.
+   * @es Informa qué canales de notificación externos están configurados (lee env vars en servidor).
+   *     No se exponen valores sensibles — solo flags booleanos.
+   */
+  app.get('/api/notifications/channels', (req: Request, res: Response) => {
+    const authReq = req as AuthenticatedRequest
+    if (!authReq.auth) {
+      res.status(401).json({ success: false, error: 'Authentication required' })
+      return
+    }
+    res.json({
+      success: true,
+      data: {
+        inApp: true,
+        email: isSmtpConfigured(),
+        whatsapp: isTwilioConfigured(),
+      },
+    })
+  })
 
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(getOpenApiDocument()))
 
@@ -324,13 +347,13 @@ export function createApp(prisma: PrismaClient): Application {
         return [newFactura, updated] as const
       })
 
-      // Notify managers if balance exceeds credit limit (non-blocking)
+      // Dispatch to all configured channels if balance exceeds credit limit (non-blocking)
       if (
         updatedCliente.creditLimit !== null &&
         Number(updatedCliente.balance) > Number(updatedCliente.creditLimit)
       ) {
         const authReq = req as AuthenticatedRequest
-        notifyManagers(prisma, authReq.auth!.claims.tenantId, 'credit_limit_exceeded', {
+        dispatchNotification(prisma, authReq.auth!.claims.tenantId, 'credit_limit_exceeded', {
           clienteId: updatedCliente.id,
           rsocial: updatedCliente.rsocial,
           amount: String(updatedCliente.balance),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -407,6 +407,19 @@ export const notificationsAPI = {
   },
 }
 
+// ============ NOTIFICATION CHANNELS ============
+
+export const notifChannelsAPI = {
+  status: async (): Promise<{ inApp: boolean; email: boolean; whatsapp: boolean }> => {
+    try {
+      const response = await api.get<{ success: boolean; data: { inApp: boolean; email: boolean; whatsapp: boolean } }>('/notifications/channels')
+      return response.data.data
+    } catch (error) {
+      return handleError(error as AxiosError<ApiErrorPayload>)
+    }
+  },
+}
+
 // ============ ZONAS DE ENTREGA ============
 
 export const zonasEntregaAPI = {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -103,6 +103,16 @@
       "invoice_due_soon": "Invoice due soon"
     }
   },
+  "notifChannels": {
+    "title": "Notification channels",
+    "subtitle": "Channels configured for this tenant (read-only in this version)",
+    "inApp": "In-app",
+    "email": "Email (SMTP)",
+    "whatsapp": "WhatsApp (Twilio)",
+    "active": "Active",
+    "inactive": "Not configured",
+    "loadError": "Could not load channel status"
+  },
   "dashboard": {
     "title": "Today's summary",
     "ventasHoy": "Today's sales",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -103,6 +103,16 @@
       "invoice_due_soon": "Factura por vencer"
     }
   },
+  "notifChannels": {
+    "title": "Canales de notificación",
+    "subtitle": "Canales configurados para este tenant (solo lectura en esta versión)",
+    "inApp": "In-app",
+    "email": "Email (SMTP)",
+    "whatsapp": "WhatsApp (Twilio)",
+    "active": "Activo",
+    "inactive": "No configurado",
+    "loadError": "No se pudo cargar el estado de los canales"
+  },
   "dashboard": {
     "title": "Resumen del día",
     "ventasHoy": "Ventas del día",

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -103,6 +103,16 @@
       "invoice_due_soon": "Fatura a vencer"
     }
   },
+  "notifChannels": {
+    "title": "Canais de notificação",
+    "subtitle": "Canais configurados para este tenant (somente leitura nesta versão)",
+    "inApp": "In-app",
+    "email": "Email (SMTP)",
+    "whatsapp": "WhatsApp (Twilio)",
+    "active": "Ativo",
+    "inactive": "Não configurado",
+    "loadError": "Não foi possível carregar o status dos canais"
+  },
   "dashboard": {
     "title": "Resumo do dia",
     "ventasHoy": "Vendas de hoje",

--- a/src/pages/configuracion/NotifChannelsPanel.tsx
+++ b/src/pages/configuracion/NotifChannelsPanel.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { notifChannelsAPI } from '@/lib/api'
+
+type ChannelStatus = { inApp: boolean; email: boolean; whatsapp: boolean }
+
+function ChannelRow({ label, active }: { label: string; active: boolean }) {
+  const { t } = useTranslation('common')
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-slate-100 dark:border-slate-700 last:border-0">
+      <span className="text-sm text-slate-700 dark:text-slate-300">{label}</span>
+      <span
+        className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+          active
+            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+            : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
+        }`}
+      >
+        {active ? t('notifChannels.active') : t('notifChannels.inactive')}
+      </span>
+    </div>
+  )
+}
+
+export default function NotifChannelsPanel() {
+  const { t } = useTranslation('common')
+  const [status, setStatus] = useState<ChannelStatus | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    notifChannelsAPI
+      .status()
+      .then((data) => setStatus(data))
+      .catch(() => setError(true))
+  }, [])
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-5">
+      <h2 className="text-base font-semibold text-slate-800 dark:text-slate-200 mb-1">
+        {t('notifChannels.title')}
+      </h2>
+      <p className="text-xs text-slate-500 dark:text-slate-400 mb-4">{t('notifChannels.subtitle')}</p>
+
+      {error ? (
+        <p className="text-sm text-red-500">{t('notifChannels.loadError')}</p>
+      ) : status === null ? (
+        <p className="text-sm text-slate-400">{t('status.loading')}</p>
+      ) : (
+        <div>
+          <ChannelRow label={t('notifChannels.inApp')} active={status.inApp} />
+          <ChannelRow label={t('notifChannels.email')} active={status.email} />
+          <ChannelRow label={t('notifChannels.whatsapp')} active={status.whatsapp} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/configuracion/index.tsx
+++ b/src/pages/configuracion/index.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import NotifChannelsPanel from './NotifChannelsPanel'
 
 const TILES = [
   { key: 'users', path: '/users', icon: '👥' },
@@ -10,10 +11,12 @@ export default function ConfiguracionPage() {
   const { t } = useTranslation('common')
 
   return (
-    <div className="p-8 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6">
+    <div className="p-8 max-w-4xl mx-auto space-y-8">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
         {t('nav.configuracion')}
       </h1>
+
+      {/* Section tiles */}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {TILES.map((tile) => (
           <Link
@@ -28,6 +31,9 @@ export default function ConfiguracionPage() {
           </Link>
         ))}
       </div>
+
+      {/* Notification channels status */}
+      <NotifChannelsPanel />
     </div>
   )
 }

--- a/tests/api/channels.test.ts
+++ b/tests/api/channels.test.ts
@@ -1,0 +1,225 @@
+/**
+ * @en Tests for server/channels.ts — dispatchNotification, isSmtpConfigured, isTwilioConfigured.
+ *     nodemailer and twilio are vi.mock'd so no real network calls happen.
+ * @es Tests para server/channels.ts — verifican fallback silencioso y llamadas reales (con mock).
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import type { PrismaClient } from '@prisma/client'
+import { createApp } from '../../server/createApp'
+
+// ─── Hoisted mocks (must be declared before vi.mock factories) ─────────────────
+
+const { mockSendMail, mockCreateTransport, mockTwilioCreate } = vi.hoisted(() => {
+  const mockSendMail = vi.fn().mockResolvedValue({ messageId: 'test-id' })
+  const mockCreateTransport = vi.fn().mockReturnValue({ sendMail: mockSendMail })
+  const mockTwilioCreate = vi.fn().mockResolvedValue({ sid: 'SM-test' })
+  return { mockSendMail, mockCreateTransport, mockTwilioCreate }
+})
+
+vi.mock('nodemailer', () => ({
+  default: { createTransport: mockCreateTransport },
+}))
+
+vi.mock('twilio', () => ({
+  default: vi.fn().mockReturnValue({
+    messages: { create: mockTwilioCreate },
+  }),
+}))
+
+// ─── Minimal Prisma mock ──────────────────────────────────────────────────────
+
+const MANAGER_USER = { id: 7 }
+
+function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  return {
+    deliveryZone: { findMany: vi.fn().mockResolvedValue([]), findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue(null), update: vi.fn().mockResolvedValue(null) },
+    cliente: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue({ email: 'mgr@example.com', telef: '+5491155550000' }),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+    },
+    articulo: { findMany: vi.fn().mockResolvedValue([]) },
+    rubro: { findMany: vi.fn().mockResolvedValue([]) },
+    formaPago: { findMany: vi.fn().mockResolvedValue([]) },
+    factura: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: 1, total: 5000, items: [] }),
+      aggregate: vi.fn().mockResolvedValue({ _count: { id: 0 }, _sum: { total: null } }),
+    },
+    notification: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    auditEvent: { create: vi.fn().mockResolvedValue({ id: 1 }) },
+    appUser: {
+      count: vi.fn().mockResolvedValue(1),
+      findMany: vi.fn().mockResolvedValue([MANAGER_USER]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+    },
+    tenant: {
+      findUnique: vi.fn().mockResolvedValue({ id: 1, slug: 'demo', active: true }),
+    },
+    appSession: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    $transaction: vi.fn(async (fn: unknown) => {
+      if (typeof fn === 'function') return fn(buildPrismaMock())
+      return fn
+    }),
+    ...overrides,
+  } as unknown as PrismaClient
+}
+
+// ─── GET /api/notifications/channels ──────────────────────────────────────────
+
+describe('GET /api/notifications/channels', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+    delete process.env.SMTP_HOST
+    delete process.env.SMTP_PORT
+    delete process.env.SMTP_USER
+    delete process.env.SMTP_PASS
+    delete process.env.SMTP_FROM
+    delete process.env.TWILIO_ACCOUNT_SID
+    delete process.env.TWILIO_AUTH_TOKEN
+    delete process.env.TWILIO_WHATSAPP_FROM
+  })
+
+  it('reports inApp:true, email:false, whatsapp:false when no env vars set', async () => {
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/notifications/channels').expect(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data).toEqual({ inApp: true, email: false, whatsapp: false })
+  })
+
+  it('reports email:true when SMTP vars are all set', async () => {
+    process.env.SMTP_HOST = 'smtp.example.com'
+    process.env.SMTP_PORT = '587'
+    process.env.SMTP_USER = 'user'
+    process.env.SMTP_PASS = 'pass'
+    process.env.SMTP_FROM = 'no-reply@example.com'
+
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/notifications/channels').expect(200)
+    expect(res.body.data.email).toBe(true)
+    expect(res.body.data.whatsapp).toBe(false)
+  })
+
+  it('reports whatsapp:true when Twilio vars are all set', async () => {
+    process.env.TWILIO_ACCOUNT_SID = 'ACtest'
+    process.env.TWILIO_AUTH_TOKEN = 'token'
+    process.env.TWILIO_WHATSAPP_FROM = '+14155238886'
+
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/notifications/channels').expect(200)
+    expect(res.body.data.email).toBe(false)
+    expect(res.body.data.whatsapp).toBe(true)
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'false'
+    const app = createApp(buildPrismaMock())
+    await request(app).get('/api/notifications/channels').expect(401)
+  })
+})
+
+// ─── dispatchNotification — external channels ──────────────────────────────────
+
+describe('dispatchNotification — silent fallback when SMTP unconfigured', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'seller'
+    delete process.env.SMTP_HOST
+    delete process.env.SMTP_PORT
+    delete process.env.SMTP_USER
+    delete process.env.SMTP_PASS
+    delete process.env.SMTP_FROM
+    delete process.env.TWILIO_ACCOUNT_SID
+    delete process.env.TWILIO_AUTH_TOKEN
+    delete process.env.TWILIO_WHATSAPP_FROM
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    delete process.env.SMTP_HOST
+    delete process.env.SMTP_PORT
+    delete process.env.SMTP_USER
+    delete process.env.SMTP_PASS
+    delete process.env.SMTP_FROM
+    delete process.env.TWILIO_ACCOUNT_SID
+    delete process.env.TWILIO_AUTH_TOKEN
+    delete process.env.TWILIO_WHATSAPP_FROM
+  })
+
+  it('does not call nodemailer when SMTP is not configured', async () => {
+    // dispatchNotification is called internally by POST /api/facturas when balance > creditLimit
+    const { dispatchNotification } = await import('../../server/channels')
+    const prisma = buildPrismaMock()
+    await dispatchNotification(prisma, 1, 'credit_limit_exceeded', {
+      clienteId: 1,
+      rsocial: 'Test SA',
+      amount: '10000',
+      limit: '5000',
+    })
+
+    expect(mockCreateTransport).not.toHaveBeenCalled()
+  })
+
+  it('calls nodemailer when SMTP is fully configured', async () => {
+    process.env.SMTP_HOST = 'smtp.example.com'
+    process.env.SMTP_PORT = '587'
+    process.env.SMTP_USER = 'user'
+    process.env.SMTP_PASS = 'pass'
+    process.env.SMTP_FROM = 'no-reply@example.com'
+
+    const { dispatchNotification } = await import('../../server/channels')
+    const prisma = buildPrismaMock()
+    await dispatchNotification(prisma, 1, 'credit_limit_exceeded', {
+      clienteId: 1,
+      rsocial: 'ACME SA',
+      amount: '20000',
+      limit: '10000',
+    })
+
+    // Allow the non-blocking void sendEmail to settle
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mockCreateTransport).toHaveBeenCalledOnce()
+    expect(mockSendMail).toHaveBeenCalledOnce()
+    const mailArgs = mockSendMail.mock.calls[0][0]
+    expect(mailArgs.subject).toContain('ACME SA')
+  })
+
+  it('swallows nodemailer error without throwing', async () => {
+    process.env.SMTP_HOST = 'smtp.example.com'
+    process.env.SMTP_PORT = '587'
+    process.env.SMTP_USER = 'user'
+    process.env.SMTP_PASS = 'pass'
+    process.env.SMTP_FROM = 'no-reply@example.com'
+
+    mockSendMail.mockRejectedValueOnce(new Error('SMTP connection refused'))
+
+    const { dispatchNotification } = await import('../../server/channels')
+    const prisma = buildPrismaMock()
+
+    // Must resolve without throwing
+    await expect(
+      dispatchNotification(prisma, 1, 'invoice_overdue', { clienteId: 1, rsocial: 'ACME SA' }),
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary  - **`server/channels.ts`** ÔÇö `dispatchNotification(prisma, tenantId, type, payload)`: orquesta los 3 canales en orden: in-app (siempre) ÔåÆ email (SMTP, si configurado) ÔåÆ WhatsApp (Twilio, si configurado). Cada canal externo usa `try/catch` + `console.warn`; nunca propaga errores. - **`isSmtpConfigured()`** / **`isTwilioConfigured()`**: leen env vars en tiempo de llamada ÔåÆ `SMTP_HOST/PORT/USER/PASS/FROM` y `TWILIO_ACCOUNT_SID/AUTH_TOKEN/WHATSAPP_FROM` - **`createApp.ts`**: `POST /api/facturas` ahora usa `dispatchNotification` (reemplaza `notifyManagers` directo) - **`GET /api/notifications/channels`**: devuelve `{ inApp, email, whatsapp }` (booleans) ÔÇö sin exponer credenciales - **Frontend**: `NotifChannelsPanel` en `/configuracion` ÔÇö muestra estado de cada canal con badge verde/gris - **i18n**: secci├│n `notifChannels.*` en `common.json` (ES/EN/PT-BR) - **OpenAPI**: ruta documentada  ## Test plan  - [x] 7 tests en `tests/api/channels.test.ts` ÔÇö nodemailer/twilio mockeados con `vi.hoisted`   - Fallback silencioso sin env vars   - `createTransport` + `sendMail` llamados cuando SMTP est├í completo   - Error de SMTP swallowed sin throw   - Status endpoint: false/false sin vars, true cuando configurado, 401 sin auth - [x] Suite completa: **254/254 passing** - [ ] Manual: configurar `SMTP_*` en `.env.local` ÔåÆ verificar badge verde en `/configuracion`  Closes #33  ­ƒñû Generated with [Claude Code](https://claude.com/claude-code)

Closes #33