### PR TITLE
fix(api): enforce server-side validation on POST/PUT

### DIFF
--- a/docs/api/openapi-reference.generated.md
+++ b/docs/api/openapi-reference.generated.md
@@ -858,6 +858,27 @@ One-time endpoint to create initial tenant and owner user.
 }
 ```
 
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
+
 ##### Status: 401 Authentication required or invalid credentials
 
 ###### Content-Type: application/json
@@ -1243,6 +1264,27 @@ One-time endpoint to create initial tenant and owner user.
     "deliveryZoneId": 1,
     "additionalProperty": "anything"
   }
+}
+```
+
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
 }
 ```
 
@@ -1668,6 +1710,27 @@ One-time endpoint to create initial tenant and owner user.
 }
 ```
 
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
+
 ##### Status: 401 Authentication required or invalid credentials
 
 ###### Content-Type: application/json
@@ -2022,6 +2085,27 @@ One-time endpoint to create initial tenant and owner user.
 }
 ```
 
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
+
 ##### Status: 401 Authentication required or invalid credentials
 
 ###### Content-Type: application/json
@@ -2262,6 +2346,27 @@ One-time endpoint to create initial tenant and owner user.
     "nombre": "",
     "additionalProperty": "anything"
   }
+}
+```
+
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
 }
 ```
 
@@ -2963,6 +3068,27 @@ One-time endpoint to create initial tenant and owner user.
 }
 ```
 
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
+
 ##### Status: 401 Authentication required or invalid credentials
 
 ###### Content-Type: application/json
@@ -3275,7 +3401,26 @@ Sets `estado` to `N` (anulada), reverses the customer balance by the invoice tot
 }
 ```
 
-##### Status: 400
+##### Status: 400 Request payload is invalid
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
 
 ##### Status: 401 Authentication required or invalid credentials
 
@@ -3319,7 +3464,26 @@ Sets `estado` to `N` (anulada), reverses the customer balance by the invoice tot
 }
 ```
 
-##### Status: 404
+##### Status: 404 Invoice not found
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `string`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "success": false,
+  "error": ""
+}
+```
 
 ##### Status: 409 Invoice already voided
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -156,6 +156,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClienteEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -208,6 +210,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClienteEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -254,6 +258,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArticuloEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -306,6 +312,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArticuloEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -346,6 +354,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RubroEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -386,6 +396,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FacturaEnvelope'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
         '401':
@@ -420,9 +432,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/FacturaEnvelope'
         '400':
-          $ref: '#/components/responses/BadRequestError'
+          $ref: '#/components/responses/BadRequest'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Invoice not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorEnvelope'
         '409':
           description: Invoice already voided
           content:

--- a/docs/evidence/sbom-cyclonedx.json
+++ b/docs/evidence/sbom-cyclonedx.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "version": 1,
-  "serialNumber": "urn:uuid:d367bb15-dbe5-48fc-97df-0e052b203bb6",
+  "serialNumber": "urn:uuid:287f1f9c-fbf9-4517-805a-beee3eaf7608",
   "metadata": {
-    "timestamp": "2026-04-16T12:15:05.990Z",
+    "timestamp": "2026-04-16T14:34:20.130Z",
     "tools": {
       "components": [
         {

--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -12,6 +12,7 @@ import { registerUserRoutes } from './users'
 import { registerDashboardRoutes } from './dashboard'
 import { registerNotificationRoutes } from './notifications'
 import { dispatchNotification, isSmtpConfigured, isTwilioConfigured } from './channels'
+import { validateCUIT } from '../src/lib/validators'
 
 const DEFAULT_CORS_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'] as const
 
@@ -42,6 +43,298 @@ export function getCorsAllowedOrigins(): Set<string> {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+type ValidationSuccess<T> = { ok: true; value: T }
+type ValidationFailure = { ok: false; error: string }
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure
+
+type ClienteInput = {
+  codigo: number
+  rsocial: string
+  condIva: 'RI' | 'Mono' | 'CF' | 'Exento'
+  activo: boolean
+  fantasia?: string | null
+  cuit?: string | null
+  domicilio?: string | null
+  localidad?: string | null
+  cpost?: string | null
+  telef?: string | null
+  email?: string | null
+  creditLimit?: number | null
+  creditDays?: number
+  suspended?: boolean
+  deliveryZoneId?: number | null
+}
+
+type ArticuloInput = {
+  codigo: number
+  descripcion: string
+  rubroId: number
+  condIva: '1' | '2' | '3'
+  umedida: string
+  precioLista1: number
+  precioLista2: number
+  costo: number
+  stock: number
+  minimo: number
+  activo: boolean
+}
+
+type RubroInput = {
+  codigo: number
+  nombre: string
+}
+
+type FacturaItemInput = {
+  articuloId: number
+  cantidad: number
+  precio: number
+  dscto: number
+  subtotal: number
+}
+
+type FacturaInput = {
+  fecha: string
+  tipo: 'A' | 'B'
+  prefijo?: string
+  numero: number
+  clienteId: number
+  formaPagoId?: number | null
+  neto1: number
+  neto2: number
+  neto3: number
+  iva1: number
+  iva2: number
+  total: number
+  items: FacturaItemInput[]
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseOptionalString(value: unknown, maxLength: number, field: string): ValidationResult<string | null | undefined> {
+  if (value === undefined) return { ok: true, value: undefined }
+  if (value === null) return { ok: true, value: null }
+  if (typeof value !== 'string') return { ok: false, error: `${field} must be a string` }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return { ok: true, value: null }
+  if (trimmed.length > maxLength) return { ok: false, error: `${field} must be at most ${maxLength} characters` }
+  return { ok: true, value: trimmed }
+}
+
+function parseOptionalNumber(value: unknown, field: string, min?: number): ValidationResult<number | null | undefined> {
+  if (value === undefined) return { ok: true, value: undefined }
+  if (value === null) return { ok: true, value: null }
+  if (typeof value !== 'number' || Number.isNaN(value)) return { ok: false, error: `${field} must be a number` }
+  if (min !== undefined && value < min) return { ok: false, error: `${field} must be >= ${min}` }
+  return { ok: true, value }
+}
+
+function parseRequiredNumber(value: unknown, field: string, min?: number): ValidationResult<number> {
+  if (typeof value !== 'number' || Number.isNaN(value)) return { ok: false, error: `${field} must be a number` }
+  if (min !== undefined && value < min) return { ok: false, error: `${field} must be >= ${min}` }
+  return { ok: true, value }
+}
+
+function parseRequiredInteger(value: unknown, field: string, min?: number): ValidationResult<number> {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return { ok: false, error: `${field} must be an integer` }
+  if (min !== undefined && value < min) return { ok: false, error: `${field} must be >= ${min}` }
+  return { ok: true, value }
+}
+
+function validateClienteInput(raw: unknown): ValidationResult<ClienteInput> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  const codigo = parseRequiredInteger(raw.codigo, 'codigo', 1)
+  if (!codigo.ok) return codigo
+  if (typeof raw.rsocial !== 'string' || raw.rsocial.trim().length < 3 || raw.rsocial.trim().length > 30) {
+    return { ok: false, error: 'rsocial must be a string between 3 and 30 characters' }
+  }
+  if (typeof raw.condIva !== 'string' || !['RI', 'Mono', 'CF', 'Exento'].includes(raw.condIva)) {
+    return { ok: false, error: 'condIva must be one of: RI, Mono, CF, Exento' }
+  }
+  if (typeof raw.activo !== 'boolean') return { ok: false, error: 'activo must be a boolean' }
+
+  const fantasia = parseOptionalString(raw.fantasia, 30, 'fantasia')
+  if (!fantasia.ok) return fantasia
+  const domicilio = parseOptionalString(raw.domicilio, 40, 'domicilio')
+  if (!domicilio.ok) return domicilio
+  const localidad = parseOptionalString(raw.localidad, 25, 'localidad')
+  if (!localidad.ok) return localidad
+  const cpost = parseOptionalString(raw.cpost, 8, 'cpost')
+  if (!cpost.ok) return cpost
+  const telef = parseOptionalString(raw.telef, 25, 'telef')
+  if (!telef.ok) return telef
+  const email = parseOptionalString(raw.email, 50, 'email')
+  if (!email.ok) return email
+
+  const cuit = parseOptionalString(raw.cuit, 14, 'cuit')
+  if (!cuit.ok) return cuit
+  if (cuit.value && !validateCUIT(cuit.value)) return { ok: false, error: 'cuit must be a valid Argentine CUIT' }
+
+  const creditLimit = parseOptionalNumber(raw.creditLimit, 'creditLimit', 0)
+  if (!creditLimit.ok) return creditLimit
+  const creditDays = parseOptionalNumber(raw.creditDays, 'creditDays', 0)
+  if (!creditDays.ok) return creditDays
+  if (creditDays.value !== undefined && creditDays.value !== null && !Number.isInteger(creditDays.value)) {
+    return { ok: false, error: 'creditDays must be an integer' }
+  }
+  if (raw.suspended !== undefined && typeof raw.suspended !== 'boolean') {
+    return { ok: false, error: 'suspended must be a boolean' }
+  }
+  const deliveryZoneId = parseOptionalNumber(raw.deliveryZoneId, 'deliveryZoneId', 1)
+  if (!deliveryZoneId.ok) return deliveryZoneId
+  if (deliveryZoneId.value !== undefined && deliveryZoneId.value !== null && !Number.isInteger(deliveryZoneId.value)) {
+    return { ok: false, error: 'deliveryZoneId must be an integer' }
+  }
+
+  return {
+    ok: true,
+    value: {
+      codigo: codigo.value,
+      rsocial: raw.rsocial.trim(),
+      condIva: raw.condIva as ClienteInput['condIva'],
+      activo: raw.activo,
+      ...(fantasia.value !== undefined && { fantasia: fantasia.value }),
+      ...(cuit.value !== undefined && { cuit: cuit.value }),
+      ...(domicilio.value !== undefined && { domicilio: domicilio.value }),
+      ...(localidad.value !== undefined && { localidad: localidad.value }),
+      ...(cpost.value !== undefined && { cpost: cpost.value }),
+      ...(telef.value !== undefined && { telef: telef.value }),
+      ...(email.value !== undefined && { email: email.value }),
+      ...(creditLimit.value !== undefined && { creditLimit: creditLimit.value }),
+      ...(creditDays.value !== undefined && { creditDays: creditDays.value ?? 0 }),
+      ...(raw.suspended !== undefined && { suspended: raw.suspended }),
+      ...(deliveryZoneId.value !== undefined && { deliveryZoneId: deliveryZoneId.value }),
+    },
+  }
+}
+
+function validateArticuloInput(raw: unknown): ValidationResult<ArticuloInput> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  const codigo = parseRequiredInteger(raw.codigo, 'codigo', 1)
+  if (!codigo.ok) return codigo
+  if (typeof raw.descripcion !== 'string' || raw.descripcion.trim().length < 3 || raw.descripcion.trim().length > 30) {
+    return { ok: false, error: 'descripcion must be a string between 3 and 30 characters' }
+  }
+  const rubroId = parseRequiredInteger(raw.rubroId, 'rubroId', 1)
+  if (!rubroId.ok) return rubroId
+  if (typeof raw.condIva !== 'string' || !['1', '2', '3'].includes(raw.condIva)) {
+    return { ok: false, error: 'condIva must be one of: 1, 2, 3' }
+  }
+  if (typeof raw.umedida !== 'string' || raw.umedida.trim().length < 2 || raw.umedida.trim().length > 6) {
+    return { ok: false, error: 'umedida must be a string between 2 and 6 characters' }
+  }
+  const precioLista1 = parseRequiredNumber(raw.precioLista1, 'precioLista1', 0.01)
+  if (!precioLista1.ok) return precioLista1
+  const precioLista2 = parseRequiredNumber(raw.precioLista2, 'precioLista2', 0.01)
+  if (!precioLista2.ok) return precioLista2
+  const costo = parseRequiredNumber(raw.costo, 'costo', 0.01)
+  if (!costo.ok) return costo
+  const stock = parseRequiredInteger(raw.stock, 'stock', 0)
+  if (!stock.ok) return stock
+  const minimo = parseRequiredInteger(raw.minimo, 'minimo', 0)
+  if (!minimo.ok) return minimo
+  if (typeof raw.activo !== 'boolean') return { ok: false, error: 'activo must be a boolean' }
+
+  return {
+    ok: true,
+    value: {
+      codigo: codigo.value,
+      descripcion: raw.descripcion.trim(),
+      rubroId: rubroId.value,
+      condIva: raw.condIva as ArticuloInput['condIva'],
+      umedida: raw.umedida.trim(),
+      precioLista1: precioLista1.value,
+      precioLista2: precioLista2.value,
+      costo: costo.value,
+      stock: stock.value,
+      minimo: minimo.value,
+      activo: raw.activo,
+    },
+  }
+}
+
+function validateRubroInput(raw: unknown): ValidationResult<RubroInput> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  const codigo = parseRequiredInteger(raw.codigo, 'codigo', 1)
+  if (!codigo.ok) return codigo
+  if (typeof raw.nombre !== 'string' || raw.nombre.trim().length === 0 || raw.nombre.trim().length > 20) {
+    return { ok: false, error: 'nombre must be a string between 1 and 20 characters' }
+  }
+  return { ok: true, value: { codigo: codigo.value, nombre: raw.nombre.trim() } }
+}
+
+function validateFacturaInput(raw: unknown): ValidationResult<FacturaInput> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  if (typeof raw.fecha !== 'string' || raw.fecha.trim().length === 0) return { ok: false, error: 'fecha is required' }
+  if (typeof raw.tipo !== 'string' || !['A', 'B'].includes(raw.tipo)) return { ok: false, error: 'tipo must be A or B' }
+  const numero = parseRequiredInteger(raw.numero, 'numero', 1)
+  if (!numero.ok) return numero
+  const clienteId = parseRequiredInteger(raw.clienteId, 'clienteId', 1)
+  if (!clienteId.ok) return clienteId
+  if (raw.prefijo !== undefined && typeof raw.prefijo !== 'string') return { ok: false, error: 'prefijo must be a string' }
+  const formaPagoId = raw.formaPagoId
+  if (
+    formaPagoId !== undefined &&
+    formaPagoId !== null &&
+    (typeof formaPagoId !== 'number' || !Number.isInteger(formaPagoId) || formaPagoId < 1)
+  ) {
+    return { ok: false, error: 'formaPagoId must be a positive integer or null' }
+  }
+  const neto1 = parseRequiredNumber(raw.neto1, 'neto1', 0)
+  if (!neto1.ok) return neto1
+  const neto2 = parseRequiredNumber(raw.neto2, 'neto2', 0)
+  if (!neto2.ok) return neto2
+  const neto3 = parseRequiredNumber(raw.neto3, 'neto3', 0)
+  if (!neto3.ok) return neto3
+  const iva1 = parseRequiredNumber(raw.iva1, 'iva1', 0)
+  if (!iva1.ok) return iva1
+  const iva2 = parseRequiredNumber(raw.iva2, 'iva2', 0)
+  if (!iva2.ok) return iva2
+  const total = parseRequiredNumber(raw.total, 'total', 0)
+  if (!total.ok) return total
+  if (!Array.isArray(raw.items)) return { ok: false, error: 'items must be an array' }
+  const parsedItems: FacturaItemInput[] = []
+  for (const [index, entry] of raw.items.entries()) {
+    if (!isObjectRecord(entry)) return { ok: false, error: `items[${index}] must be an object` }
+    const articuloId = parseRequiredInteger(entry.articuloId, `items[${index}].articuloId`, 1)
+    if (!articuloId.ok) return articuloId
+    const cantidad = parseRequiredNumber(entry.cantidad, `items[${index}].cantidad`, 0)
+    if (!cantidad.ok) return cantidad
+    const precio = parseRequiredNumber(entry.precio, `items[${index}].precio`, 0)
+    if (!precio.ok) return precio
+    const dscto = parseRequiredNumber(entry.dscto, `items[${index}].dscto`, 0)
+    if (!dscto.ok) return dscto
+    const subtotal = parseRequiredNumber(entry.subtotal, `items[${index}].subtotal`, 0)
+    if (!subtotal.ok) return subtotal
+    parsedItems.push({
+      articuloId: articuloId.value,
+      cantidad: cantidad.value,
+      precio: precio.value,
+      dscto: dscto.value,
+      subtotal: subtotal.value,
+    })
+  }
+  return {
+    ok: true,
+    value: {
+      fecha: raw.fecha.trim(),
+      tipo: raw.tipo as 'A' | 'B',
+      ...(typeof raw.prefijo === 'string' && { prefijo: raw.prefijo }),
+      numero: numero.value,
+      clienteId: clienteId.value,
+      ...(formaPagoId !== undefined && { formaPagoId: formaPagoId as number | null }),
+      neto1: neto1.value,
+      neto2: neto2.value,
+      neto3: neto3.value,
+      iva1: iva1.value,
+      iva2: iva2.value,
+      total: total.value,
+      items: parsedItems,
+    },
+  }
 }
 
 let cachedOpenApiDocument: Record<string, unknown> | undefined
@@ -171,8 +464,13 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/clientes', requirePermission('customers.manage'), async (req: Request, res: Response) => {
     try {
+      const parsed = validateClienteInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
       const cliente = await prisma.cliente.create({
-        data: req.body,
+        data: parsed.value,
       })
       await writeAudit(req as AuthenticatedRequest, 'cliente_create', 'cliente', String(cliente.id))
       res.json({ success: true, data: cliente })
@@ -183,12 +481,17 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/clientes/:id', requirePermission('customers.manage'), async (req: Request, res: Response) => {
     try {
+      const parsed = validateClienteInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
       const authReq = req as AuthenticatedRequest
       const role = authReq.auth?.claims.role
       const canManageFinancials = role === 'owner' || role === 'manager'
 
       // Strip financial management fields for roles without the right
-      const { creditLimit, creditDays, suspended, ...baseBody } = req.body as Record<string, unknown>
+      const { creditLimit, creditDays, suspended, ...baseBody } = parsed.value
       const data = canManageFinancials
         ? { ...baseBody, creditLimit, creditDays, suspended }
         : baseBody
@@ -239,8 +542,13 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/articulos', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
+      const parsed = validateArticuloInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
       const articulo = await prisma.articulo.create({
-        data: req.body,
+        data: parsed.value,
       })
       await writeAudit(req as AuthenticatedRequest, 'articulo_create', 'articulo', String(articulo.id))
       res.json({ success: true, data: articulo })
@@ -251,9 +559,14 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/articulos/:id', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
+      const parsed = validateArticuloInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
       const articulo = await prisma.articulo.update({
         where: { id: parseInt(String(req.params.id), 10) },
-        data: req.body,
+        data: parsed.value,
       })
       await writeAudit(req as AuthenticatedRequest, 'articulo_update', 'articulo', String(articulo.id))
       res.json({ success: true, data: articulo })
@@ -277,7 +590,12 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/rubros', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
-      const rubro = await prisma.rubro.create({ data: req.body })
+      const parsed = validateRubroInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
+      const rubro = await prisma.rubro.create({ data: parsed.value })
       await writeAudit(req as AuthenticatedRequest, 'rubro_create', 'rubro', String(rubro.id))
       res.json({ success: true, data: rubro })
     } catch (err: unknown) {
@@ -314,11 +632,13 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/facturas', requirePermission('sales.create'), async (req: Request, res: Response) => {
     try {
-      const { items, ...factura } = req.body as { items: Record<string, unknown>[] } & Record<
-        string,
-        unknown
-      >
-      const clienteId = parseInt(String(factura.clienteId), 10)
+      const parsed = validateFacturaInput(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
+      }
+      const { items, ...factura } = parsed.value
+      const clienteId = factura.clienteId
 
       // Check suspension before creating the factura
       const clienteCheck = await prisma.cliente.findUnique({

--- a/tests/api/channels.test.ts
+++ b/tests/api/channels.test.ts
@@ -241,9 +241,8 @@ describe('POST /api/facturas — dispatchNotification failure is swallowed', () 
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
-        // findFirst is used for suspension check
         findFirst: vi.fn().mockResolvedValue({ id: 1, suspended: false }),
-        findUnique: vi.fn().mockResolvedValue({ email: null, telef: null }),
+        findUnique: vi.fn().mockResolvedValue({ suspended: false }),
         create: vi.fn().mockResolvedValue(null),
         update: vi.fn().mockResolvedValue(updatedCliente),
       },
@@ -283,11 +282,19 @@ describe('POST /api/facturas — dispatchNotification failure is swallowed', () 
     const res = await request(app)
       .post('/api/facturas')
       .send({
+        fecha: new Date().toISOString(),
+        tipo: 'B',
+        prefijo: '0001',
+        numero: 1,
         clienteId: 1,
         formaPagoId: 1,
-        items: [{ articuloId: 1, qty: 1, precioUnitario: 20000, subtotal: 20000 }],
-        subtotal: 20000,
+        neto1: 16528.93,
+        neto2: 0,
+        neto3: 0,
+        iva1: 3471.07,
+        iva2: 0,
         total: 20000,
+        items: [{ articuloId: 1, cantidad: 1, precio: 20000, dscto: 0, subtotal: 20000 }],
       })
       .expect(200)
 

--- a/tests/api/clientes.test.ts
+++ b/tests/api/clientes.test.ts
@@ -36,15 +36,15 @@ const FACTURA_BODY = {
   prefijo: '0001',
   numero: 1,
   clienteId: 1,
-  neto1: '826.45',
-  neto2: '0',
-  neto3: '0',
-  iva1: '173.55',
-  iva2: '0',
-  total: '1000.00',
+  neto1: 826.45,
+  neto2: 0,
+  neto3: 0,
+  iva1: 173.55,
+  iva2: 0,
+  total: 1000.0,
   formaPagoId: null,
   estado: 'A',
-  items: [{ articuloId: 1, cantidad: 2, precio: '500.00', dscto: '0', subtotal: '1000.00' }],
+  items: [{ articuloId: 1, cantidad: 2, precio: 500.0, dscto: 0, subtotal: 1000.0 }],
 }
 
 const FACTURA_RESULT = {
@@ -396,7 +396,14 @@ describe('PUT /api/clientes/:id — financial field access', () => {
     const app = createApp(prisma)
     const res = await request(app)
       .put('/api/clientes/1')
-      .send({ rsocial: 'ACME SA', creditLimit: 5000, suspended: true })
+      .send({
+        codigo: CLIENTE_BASE.codigo,
+        rsocial: 'ACME SA',
+        condIva: 'RI',
+        activo: true,
+        creditLimit: 5000,
+        suspended: true,
+      })
       .expect(200)
 
     expect(res.body.success).toBe(true)
@@ -422,7 +429,14 @@ describe('PUT /api/clientes/:id — financial field access', () => {
     const app = createApp(prisma)
     await request(app)
       .put('/api/clientes/1')
-      .send({ rsocial: 'ACME SA', creditLimit: 5000, suspended: true })
+      .send({
+        codigo: CLIENTE_BASE.codigo,
+        rsocial: 'ACME SA',
+        condIva: 'RI',
+        activo: true,
+        creditLimit: 5000,
+        suspended: true,
+      })
       .expect(200)
 
     const callArg = clienteUpdate.mock.calls[0][0] as { data: Record<string, unknown> }

--- a/tests/api/contract.test.ts
+++ b/tests/api/contract.test.ts
@@ -58,6 +58,27 @@ const facturaRow = {
   items: [] as unknown[],
 }
 
+const clienteInput = {
+  codigo: 1,
+  rsocial: 'ACME SA',
+  condIva: 'RI',
+  activo: true,
+}
+
+const articuloInput = {
+  codigo: 1,
+  descripcion: 'Producto',
+  rubroId: 1,
+  condIva: '1',
+  umedida: 'UN',
+  precioLista1: 10,
+  precioLista2: 10,
+  costo: 5,
+  stock: 0,
+  minimo: 0,
+  activo: true,
+}
+
 function buildPrisma(): PrismaClient {
   const facturaCreate = vi.fn().mockResolvedValue(facturaRow)
   // tx-level cliente.update: returns the financial summary the route uses for the credit check
@@ -137,13 +158,13 @@ describe('API — contrato OpenAPI', () => {
 
   it('POST /api/clientes', async () => {
     const app = createApp(prisma)
-    const res = await request(app).post('/api/clientes').send({}).expect(200)
+    const res = await request(app).post('/api/clientes').send(clienteInput).expect(200)
     await assertMatchesOpenApi('/api/clientes', 'post', '200', res.body)
   })
 
   it('PUT /api/clientes/:id', async () => {
     const app = createApp(prisma)
-    const res = await request(app).put('/api/clientes/1').send({}).expect(200)
+    const res = await request(app).put('/api/clientes/1').send(clienteInput).expect(200)
     await assertMatchesOpenApi('/api/clientes/{id}', 'put', '200', res.body)
   })
 
@@ -167,13 +188,13 @@ describe('API — contrato OpenAPI', () => {
 
   it('POST /api/articulos', async () => {
     const app = createApp(prisma)
-    const res = await request(app).post('/api/articulos').send({}).expect(200)
+    const res = await request(app).post('/api/articulos').send(articuloInput).expect(200)
     await assertMatchesOpenApi('/api/articulos', 'post', '200', res.body)
   })
 
   it('PUT /api/articulos/:id', async () => {
     const app = createApp(prisma)
-    const res = await request(app).put('/api/articulos/1').send({}).expect(200)
+    const res = await request(app).put('/api/articulos/1').send(articuloInput).expect(200)
     await assertMatchesOpenApi('/api/articulos/{id}', 'put', '200', res.body)
   })
 
@@ -261,14 +282,14 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
   it('POST /api/clientes', async () => {
     const p = buildPrisma()
     vi.mocked(p.cliente.create).mockRejectedValueOnce(err)
-    const res = await request(createApp(p)).post('/api/clientes').send({}).expect(500)
+    const res = await request(createApp(p)).post('/api/clientes').send(clienteInput).expect(500)
     await assertMatchesOpenApi('/api/clientes', 'post', '500', res.body)
   })
 
   it('PUT /api/clientes/:id', async () => {
     const p = buildPrisma()
     vi.mocked(p.cliente.update).mockRejectedValueOnce(err)
-    const res = await request(createApp(p)).put('/api/clientes/1').send({}).expect(500)
+    const res = await request(createApp(p)).put('/api/clientes/1').send(clienteInput).expect(500)
     await assertMatchesOpenApi('/api/clientes/{id}', 'put', '500', res.body)
   })
 
@@ -289,14 +310,14 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
   it('POST /api/articulos', async () => {
     const p = buildPrisma()
     vi.mocked(p.articulo.create).mockRejectedValueOnce(err)
-    const res = await request(createApp(p)).post('/api/articulos').send({}).expect(500)
+    const res = await request(createApp(p)).post('/api/articulos').send(articuloInput).expect(500)
     await assertMatchesOpenApi('/api/articulos', 'post', '500', res.body)
   })
 
   it('PUT /api/articulos/:id', async () => {
     const p = buildPrisma()
     vi.mocked(p.articulo.update).mockRejectedValueOnce(err)
-    const res = await request(createApp(p)).put('/api/articulos/1').send({}).expect(500)
+    const res = await request(createApp(p)).put('/api/articulos/1').send(articuloInput).expect(500)
     await assertMatchesOpenApi('/api/articulos/{id}', 'put', '500', res.body)
   })
 

--- a/tests/api/request-validation.test.ts
+++ b/tests/api/request-validation.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import type { PrismaClient } from '@prisma/client'
+import { createApp } from '../../server/createApp'
+
+function buildPrismaMock(): PrismaClient {
+  return {
+    cliente: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue({ id: 1, suspended: false }),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    articulo: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue({ id: 1 }),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    rubro: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    formaPago: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    factura: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: 1, total: 100, items: [] }),
+      aggregate: vi.fn().mockResolvedValue({ _count: { id: 0 }, _sum: { total: null } }),
+    },
+    notification: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    auditEvent: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    appUser: {
+      count: vi.fn().mockResolvedValue(1),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+    },
+    tenant: {
+      findUnique: vi.fn().mockResolvedValue({ id: 1, slug: 'demo', active: true }),
+    },
+    appSession: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    deliveryZone: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+    },
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') {
+        return arg(buildPrismaMock())
+      }
+      return arg
+    }),
+  } as unknown as PrismaClient
+}
+
+describe('API payload validation on POST/PUT business routes', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'owner'
+  })
+
+  it('returns 400 for invalid POST /api/clientes payload', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/clientes').send({}).expect(400)
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.cliente.create)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid PUT /api/articulos/:id payload', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    const res = await request(app).put('/api/articulos/1').send({ codigo: 0 }).expect(400)
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.articulo.update)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid POST /api/rubros payload', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/rubros').send({ codigo: 0, nombre: '' }).expect(400)
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.rubro.create)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid POST /api/facturas payload', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/facturas').send({ clienteId: 1 }).expect(400)
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.factura.create)).not.toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add explicit request validators in `server/createApp.ts` for `POST/PUT` business routes (`clientes`, `articulos`, `rubros`, `facturas`) before Prisma writes
- return actionable `400` responses for invalid payloads and remove direct persistence of unvalidated `req.body`
- align OpenAPI responses and contract tests, including new API tests for invalid payload handling

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test -- tests/api/request-validation.test.ts tests/api/contract.test.ts`
- [x] `npm run docs:generate`

## Notes
- OpenAPI contract now uses existing `BadRequest`/`ApiErrorEnvelope` references for affected endpoints and void 404 response.

Made with [Cursor](https://cursor.com)