### PR TITLE
test(pos): verify credit-limit warning in invoice UI

### DIFF
--- a/docs/evidence/sbom-cyclonedx.json
+++ b/docs/evidence/sbom-cyclonedx.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "version": 1,
-  "serialNumber": "urn:uuid:d367bb15-dbe5-48fc-97df-0e052b203bb6",
+  "serialNumber": "urn:uuid:067a5f23-faed-47e3-a9ae-c0d86a67ccc8",
   "metadata": {
-    "timestamp": "2026-04-16T12:15:05.990Z",
+    "timestamp": "2026-04-16T14:39:21.087Z",
     "tools": {
       "components": [
         {

--- a/src/pages/facturacion/NuevaFacturaForm.credit-limit.test.tsx
+++ b/src/pages/facturacion/NuevaFacturaForm.credit-limit.test.tsx
@@ -10,6 +10,8 @@ vi.mock('@/lib/api', () => ({
   },
 }))
 
+const now = new Date()
+
 const clientes: Cliente[] = [
   {
     id: 1,
@@ -19,6 +21,8 @@ const clientes: Cliente[] = [
     activo: true,
     creditLimit: 100,
     balance: 90,
+    createdAt: now,
+    updatedAt: now,
   },
 ]
 

--- a/src/pages/facturacion/NuevaFacturaForm.credit-limit.test.tsx
+++ b/src/pages/facturacion/NuevaFacturaForm.credit-limit.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@/i18n/config'
+import NuevaFacturaForm from './NuevaFacturaForm'
+import type { Articulo, Cliente, FormaPago } from '@/types'
+
+vi.mock('@/lib/api', () => ({
+  facturasAPI: {
+    create: vi.fn().mockResolvedValue({ id: 1 }),
+  },
+}))
+
+const clientes: Cliente[] = [
+  {
+    id: 1,
+    codigo: 1001,
+    rsocial: 'Cliente con limite',
+    condIva: 'RI',
+    activo: true,
+    creditLimit: 100,
+    balance: 90,
+  },
+]
+
+const articulos: Articulo[] = [
+  {
+    id: 1,
+    codigo: 1,
+    descripcion: 'Articulo 1',
+    rubroId: 1,
+    condIva: '1',
+    umedida: 'UN',
+    precioLista1: 20,
+    precioLista2: 20,
+    costo: 10,
+    stock: 100,
+    minimo: 0,
+    activo: true,
+  },
+]
+
+const formasPago: FormaPago[] = []
+
+describe('NuevaFacturaForm — warning por limite de credito', () => {
+  it('muestra el warning cuando balance + total supera el limite', async () => {
+    render(
+      <NuevaFacturaForm
+        clientes={clientes}
+        articulos={articulos}
+        formasPago={formasPago}
+        onCancel={() => {}}
+        onGuardada={() => {}}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/cliente/i), { target: { value: '1' } })
+    fireEvent.click(screen.getByRole('button', { name: /agregar ítem|agregar item/i }))
+
+    const selects = screen.getAllByRole('combobox')
+    fireEvent.change(selects[2], { target: { value: '1' } })
+    fireEvent.change(screen.getByLabelText(/número/i), { target: { value: '1' } })
+
+    expect(await screen.findByTestId('credit-limit-warning')).not.toBeNull()
+  })
+})
+

--- a/src/pages/facturacion/NuevaFacturaForm.tsx
+++ b/src/pages/facturacion/NuevaFacturaForm.tsx
@@ -190,7 +190,12 @@ export default function NuevaFacturaForm({
       )}
 
       {creditLimitWarning && (
-        <div role="alert" aria-live="polite" className="p-4 bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-600 rounded mb-4 flex items-start gap-3">
+        <div
+          data-testid="credit-limit-warning"
+          role="alert"
+          aria-live="polite"
+          className="p-4 bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-600 rounded mb-4 flex items-start gap-3"
+        >
           <span className="text-amber-600 dark:text-amber-400 text-xl leading-none" aria-hidden="true">⚠</span>
           <div className="flex-1">
             <p className="font-semibold text-amber-800 dark:text-amber-300 text-sm">


### PR DESCRIPTION
## Summary
- add stable `data-testid=credit-limit-warning` to the invoice warning banner in `NuevaFacturaForm`
- add focused UI test to verify the warning appears when `balance + total` exceeds `creditLimit`
- keep current behavior intact (warning only, seller can still proceed), aligned with existing issue scope over current POS flow

## Test plan
- [x] `npm run test -- src/pages/facturacion/NuevaFacturaForm.credit-limit.test.tsx`
- [x] `npm run docs:generate`
- [x] `npm run test` (full suite)
- [x] `npm run lint`
- [x] `npm run type-check`

Made with [Cursor](https://cursor.com)