### PR TITLE
fix(api): aislamiento multi-tenant en entidades ERP (Closes #83)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ BIZCODE_SEED_SUPERADMIN_PASSWORD=
 
 # Optional: legacy DBF tree for `npm run migrate:dbf` / `npx tsx scripts/inspect-dbf.ts` when Programa_Viejo is not under the repo root (absolute or relative to cwd).
 # PROGRAMA_VIEJO_ROOT=D:/ruta/Programa_Viejo
+
+# Optional: target Tenant.id for `npm run migrate:dbf` (defaults to the lowest Tenant.id when unset; requires at least one Tenant row, e.g. from `npx prisma db seed`).
+# BIZCODE_MIGRATION_TENANT_ID=1

--- a/.github/workflows/qa-validation.yml
+++ b/.github/workflows/qa-validation.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Run database migrations
         env:
           DATABASE_URL: postgresql://test@localhost:5432/bizcode_test?sslmode=disable

--- a/prisma/migrations/20260418183000_core_entities_tenant_scope/migration.sql
+++ b/prisma/migrations/20260418183000_core_entities_tenant_scope/migration.sql
@@ -1,0 +1,44 @@
+-- Multi-tenant scope for core ERP entities (Issue #83).
+-- Backfill: assign all existing rows to the first Tenant by id (typically `platform` from seed).
+
+ALTER TABLE "Cliente" ADD COLUMN "tenantId" INTEGER;
+ALTER TABLE "Rubro" ADD COLUMN "tenantId" INTEGER;
+ALTER TABLE "Articulo" ADD COLUMN "tenantId" INTEGER;
+ALTER TABLE "Proveedor" ADD COLUMN "tenantId" INTEGER;
+ALTER TABLE "Factura" ADD COLUMN "tenantId" INTEGER;
+
+UPDATE "Cliente" SET "tenantId" = (SELECT MIN("id") FROM "Tenant");
+UPDATE "Rubro" SET "tenantId" = (SELECT MIN("id") FROM "Tenant");
+UPDATE "Articulo" SET "tenantId" = (SELECT MIN("id") FROM "Tenant");
+UPDATE "Proveedor" SET "tenantId" = (SELECT MIN("id") FROM "Tenant");
+UPDATE "Factura" SET "tenantId" = (SELECT MIN("id") FROM "Tenant");
+
+ALTER TABLE "Cliente" ALTER COLUMN "tenantId" SET NOT NULL;
+ALTER TABLE "Rubro" ALTER COLUMN "tenantId" SET NOT NULL;
+ALTER TABLE "Articulo" ALTER COLUMN "tenantId" SET NOT NULL;
+ALTER TABLE "Proveedor" ALTER COLUMN "tenantId" SET NOT NULL;
+ALTER TABLE "Factura" ALTER COLUMN "tenantId" SET NOT NULL;
+
+DROP INDEX IF EXISTS "Cliente_codigo_key";
+DROP INDEX IF EXISTS "Rubro_codigo_key";
+DROP INDEX IF EXISTS "Articulo_codigo_key";
+DROP INDEX IF EXISTS "Proveedor_codigo_key";
+DROP INDEX IF EXISTS "Factura_tipo_prefijo_numero_key";
+
+ALTER TABLE "Cliente" ADD CONSTRAINT "Cliente_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Rubro" ADD CONSTRAINT "Rubro_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Articulo" ADD CONSTRAINT "Articulo_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Proveedor" ADD CONSTRAINT "Proveedor_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Factura" ADD CONSTRAINT "Factura_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "Cliente_tenantId_codigo_key" ON "Cliente"("tenantId", "codigo");
+CREATE UNIQUE INDEX "Rubro_tenantId_codigo_key" ON "Rubro"("tenantId", "codigo");
+CREATE UNIQUE INDEX "Articulo_tenantId_codigo_key" ON "Articulo"("tenantId", "codigo");
+CREATE UNIQUE INDEX "Proveedor_tenantId_codigo_key" ON "Proveedor"("tenantId", "codigo");
+CREATE UNIQUE INDEX "Factura_tenantId_tipo_prefijo_numero_key" ON "Factura"("tenantId", "tipo", "prefijo", "numero");
+
+CREATE INDEX "Cliente_tenantId_idx" ON "Cliente"("tenantId");
+CREATE INDEX "Rubro_tenantId_idx" ON "Rubro"("tenantId");
+CREATE INDEX "Articulo_tenantId_idx" ON "Articulo"("tenantId");
+CREATE INDEX "Proveedor_tenantId_idx" ON "Proveedor"("tenantId");
+CREATE INDEX "Factura_tenantId_idx" ON "Factura"("tenantId");

--- a/prisma/migrations/20260418183000_core_entities_tenant_scope/migration.sql
+++ b/prisma/migrations/20260418183000_core_entities_tenant_scope/migration.sql
@@ -1,5 +1,12 @@
 -- Multi-tenant scope for core ERP entities (Issue #83).
 -- Backfill: assign all existing rows to the first Tenant by id (typically `platform` from seed).
+--
+-- Fresh databases (e.g. CI `prisma migrate deploy` without seed) have zero Tenant rows.
+-- Without a row, MIN(id) is NULL and NOT NULL on ERP tables fails. Insert a bootstrap tenant.
+
+INSERT INTO "Tenant" ("name", "slug", "active", "createdAt", "updatedAt")
+SELECT 'Bootstrap', 'bootstrap-default-tenant', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "Tenant" LIMIT 1);
 
 ALTER TABLE "Cliente" ADD COLUMN "tenantId" INTEGER;
 ALTER TABLE "Rubro" ADD COLUMN "tenantId" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,9 @@ model DeliveryZone {
 
 model Cliente {
   id             Int      @id @default(autoincrement())
-  codigo         Int      @unique
+  tenantId       Int
+  tenant         Tenant   @relation(fields: [tenantId], references: [id])
+  codigo         Int
   rsocial        String   @db.VarChar(30)
   fantasia       String?  @db.VarChar(30)
   cuit           String?  @db.VarChar(14)
@@ -76,19 +78,29 @@ model Cliente {
   updatedAt      DateTime @updatedAt
 
   facturas Factura[]
+
+  @@unique([tenantId, codigo])
+  @@index([tenantId])
 }
 
 model Rubro {
-  id    Int    @id @default(autoincrement())
-  codigo Int   @unique
-  nombre String @db.VarChar(20)
+  id       Int    @id @default(autoincrement())
+  tenantId Int
+  tenant   Tenant @relation(fields: [tenantId], references: [id])
+  codigo   Int
+  nombre   String @db.VarChar(20)
 
   articulos Articulo[]
+
+  @@unique([tenantId, codigo])
+  @@index([tenantId])
 }
 
 model Articulo {
   id           Int    @id @default(autoincrement())
-  codigo       Int    @unique
+  tenantId     Int
+  tenant       Tenant @relation(fields: [tenantId], references: [id])
+  codigo       Int
   descripcion  String @db.VarChar(30)
   rubroId      Int
   rubro        Rubro  @relation(fields: [rubroId], references: [id])
@@ -104,11 +116,16 @@ model Articulo {
   updatedAt    DateTime @updatedAt
 
   facturaItems FacturaItem[]
+
+  @@unique([tenantId, codigo])
+  @@index([tenantId])
 }
 
 model Proveedor {
   id        Int      @id @default(autoincrement())
-  codigo    Int      @unique
+  tenantId  Int
+  tenant    Tenant   @relation(fields: [tenantId], references: [id])
+  codigo    Int
   rsocial   String   @db.VarChar(30)
   fantasia  String?  @db.VarChar(30)
   cuit      String?  @db.VarChar(14)
@@ -118,6 +135,9 @@ model Proveedor {
   activo    Boolean  @default(true)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([tenantId, codigo])
+  @@index([tenantId])
 }
 
 model FormaPago {
@@ -129,6 +149,8 @@ model FormaPago {
 
 model Factura {
   id        Int       @id @default(autoincrement())
+  tenantId  Int
+  tenant    Tenant    @relation(fields: [tenantId], references: [id])
   fecha     DateTime
   tipo      String    @db.VarChar(1) // A, B, C, X
   prefijo   String    @db.VarChar(4)
@@ -150,7 +172,8 @@ model Factura {
 
   items FacturaItem[]
 
-  @@unique([tipo, prefijo, numero])
+  @@unique([tenantId, tipo, prefijo, numero])
+  @@index([tenantId])
 }
 
 model FacturaItem {
@@ -189,6 +212,11 @@ model Tenant {
   notifications  Notification[]
   deliveryZones  DeliveryZone[]
   chatMessages   ChatMessage[]
+  clientes       Cliente[]
+  rubros         Rubro[]
+  articulos      Articulo[]
+  proveedores    Proveedor[]
+  facturas       Factura[]
 }
 
 model AppUser {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,9 +17,10 @@ const prisma = new PrismaClient()
  */
 async function seedOptionalCatalogFixtures(): Promise<void> {
   if (process.env.BIZCODE_SEED_FIXTURE_CATALOG !== 'true') return
+  const tenant = await prisma.tenant.findUniqueOrThrow({ where: { slug: SUPERADMIN_SEED_TENANT_SLUG } })
   await prisma.rubro.upsert({
-    where: { codigo: 1 },
-    create: { codigo: 1, nombre: 'General' },
+    where: { tenantId_codigo: { tenantId: tenant.id, codigo: 1 } },
+    create: { tenantId: tenant.id, codigo: 1, nombre: 'General' },
     update: { nombre: 'General' },
   })
   console.info('[seed] Catalog fixture: rubro codigo=1 (BIZCODE_SEED_FIXTURE_CATALOG=true).')

--- a/scripts/migrate-from-dbf.ts
+++ b/scripts/migrate-from-dbf.ts
@@ -37,6 +37,21 @@ const ARTICULOS_A_IMPORTAR = 10
 
 const prisma = new PrismaClient()
 
+async function resolveMigrationTenantId(): Promise<number> {
+  const raw = process.env.BIZCODE_MIGRATION_TENANT_ID?.trim()
+  if (raw) {
+    const id = parseInt(raw, 10)
+    if (!Number.isNaN(id) && id > 0) return id
+  }
+  const first = await prisma.tenant.findFirst({ orderBy: { id: 'asc' } })
+  if (!first) {
+    throw new Error(
+      'migrate-from-dbf: no Tenant row found. Run `npx prisma db seed` or set BIZCODE_MIGRATION_TENANT_ID.',
+    )
+  }
+  return first.id
+}
+
 type Pvar2Agg = {
   importe: number
   costoN: number
@@ -108,16 +123,16 @@ async function listCliIsMetadataOnly(): Promise<boolean> {
   return r != null && Object.prototype.hasOwnProperty.call(r, 'FIELD_NAME')
 }
 
-async function ensureRubroGeneral(): Promise<number> {
+async function ensureRubroGeneral(tenantId: number): Promise<number> {
   const rubro = await prisma.rubro.upsert({
-    where: { codigo: 1 },
-    create: { codigo: 1, nombre: 'General' },
+    where: { tenantId_codigo: { tenantId, codigo: 1 } },
+    create: { tenantId, codigo: 1, nombre: 'General' },
     update: { nombre: 'General' },
   })
   return rubro.id
 }
 
-async function migrateArticulos(rubroId: number, descrFromPvar: Map<number, string>) {
+async function migrateArticulos(tenantId: number, rubroId: number, descrFromPvar: Map<number, string>) {
   const agg = await aggregatePvar2ByArtic()
   const codes = [...agg.keys()].sort((a, b) => a - b).slice(0, ARTICULOS_A_IMPORTAR)
   if (codes.length < ARTICULOS_A_IMPORTAR) {
@@ -128,7 +143,7 @@ async function migrateArticulos(rubroId: number, descrFromPvar: Map<number, stri
   const existing = new Set(
     (
       await prisma.articulo.findMany({
-        where: { codigo: { in: codes } },
+        where: { tenantId, codigo: { in: codes } },
         select: { codigo: true },
       })
     ).map((a) => a.codigo)
@@ -142,6 +157,7 @@ async function migrateArticulos(rubroId: number, descrFromPvar: Map<number, stri
       const precio = dec2(row.importe)
       const costo = dec2(row.costoN)
       return {
+        tenantId,
         codigo,
         descripcion,
         rubroId,
@@ -163,7 +179,7 @@ async function migrateArticulos(rubroId: number, descrFromPvar: Map<number, stri
   console.log(`[migrate-from-dbf] Artículos insertados: ${result.count}`)
 }
 
-async function migrateClientesPlaceholder() {
+async function migrateClientesPlaceholder(tenantId: number) {
   const meta = await listCliIsMetadataOnly()
   if (meta) {
     console.log(
@@ -178,6 +194,7 @@ async function migrateClientesPlaceholder() {
     const n = String(i + 1).padStart(2, '0')
     const rsocial = `Cliente legado ${n}`.slice(0, 30)
     return {
+      tenantId,
       codigo,
       rsocial,
       condIva: 'RI',
@@ -188,7 +205,7 @@ async function migrateClientesPlaceholder() {
   const existing = new Set(
     (
       await prisma.cliente.findMany({
-        where: { codigo: { in: codes } },
+        where: { tenantId, codigo: { in: codes } },
         select: { codigo: true },
       })
     ).map((c) => c.codigo)
@@ -207,10 +224,11 @@ export async function runDbfMigration() {
     console.error('DATABASE_URL no está definida. Configura .env en la raíz del proyecto.')
     process.exit(1)
   }
-  const rubroId = await ensureRubroGeneral()
+  const tenantId = await resolveMigrationTenantId()
+  const rubroId = await ensureRubroGeneral(tenantId)
   const descrFromPvar = await loadPvarDescriptions()
-  await migrateClientesPlaceholder()
-  await migrateArticulos(rubroId, descrFromPvar)
+  await migrateClientesPlaceholder(tenantId)
+  await migrateArticulos(tenantId, rubroId, descrFromPvar)
   console.log('[migrate-from-dbf] Listo.')
 }
 

--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -52,6 +52,10 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+function getTenantId(req: Request): number {
+  return (req as AuthenticatedRequest).auth!.claims.tenantId
+}
+
 type ValidationSuccess<T> = { ok: true; value: T }
 type ValidationFailure = { ok: false; error: string }
 type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure
@@ -731,9 +735,11 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/clientes', requirePermission('customers.read'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const filtro = (req.query.q as string) || ''
       const clientes = await prisma.cliente.findMany({
         where: {
+          tenantId,
           OR: [
             { rsocial: { contains: filtro, mode: 'insensitive' } },
             { cuit: { contains: filtro, mode: 'insensitive' } },
@@ -763,6 +769,7 @@ export function createApp(prisma: PrismaClient): Application {
       return
     }
     try {
+          const tenantId = getTenantId(req)
           const parsedCsv = parseCsvWithFixedHeaders(file.buffer, CLIENTE_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
           if (!parsedCsv.ok) {
             res.status(400).json({ success: false, error: parsedCsv.error })
@@ -796,7 +803,7 @@ export function createApp(prisma: PrismaClient): Application {
             codigos.length === 0
               ? []
               : await prisma.cliente.findMany({
-                  where: { codigo: { in: codigos } },
+                  where: { tenantId, codigo: { in: codigos } },
                   select: { codigo: true },
                 })
           const existingSet = new Set(existing.map((e) => e.codigo))
@@ -811,7 +818,7 @@ export function createApp(prisma: PrismaClient): Application {
           let created = 0
           await prisma.$transaction(async (tx) => {
             for (const data of toInsert) {
-              await tx.cliente.create({ data })
+              await tx.cliente.create({ data: { ...data, tenantId } })
               created += 1
             }
           })
@@ -832,8 +839,9 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/clientes/:id', requirePermission('customers.read'), async (req: Request, res: Response) => {
     try {
-      const cliente = await prisma.cliente.findUnique({
-        where: { id: parseInt(String(req.params.id), 10) },
+      const tenantId = getTenantId(req)
+      const cliente = await prisma.cliente.findFirst({
+        where: { id: parseInt(String(req.params.id), 10), tenantId },
       })
       res.json({ success: true, data: cliente })
     } catch (err: unknown) {
@@ -843,13 +851,23 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/clientes', requirePermission('customers.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateClienteInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
+      if (parsed.value.deliveryZoneId != null) {
+        const zone = await prisma.deliveryZone.findFirst({
+          where: { id: parsed.value.deliveryZoneId, tenantId },
+        })
+        if (!zone) {
+          res.status(400).json({ success: false, error: 'deliveryZoneId does not belong to this tenant' })
+          return
+        }
+      }
       const cliente = await prisma.cliente.create({
-        data: parsed.value,
+        data: { ...parsed.value, tenantId },
       })
       await writeAudit(req as AuthenticatedRequest, 'cliente_create', 'cliente', String(cliente.id))
       res.json({ success: true, data: cliente })
@@ -860,6 +878,7 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/clientes/:id', requirePermission('customers.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateClienteInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
@@ -875,8 +894,25 @@ export function createApp(prisma: PrismaClient): Application {
         ? { ...baseBody, creditLimit, creditDays, suspended }
         : baseBody
 
+      if (data.deliveryZoneId != null) {
+        const zone = await prisma.deliveryZone.findFirst({
+          where: { id: data.deliveryZoneId, tenantId },
+        })
+        if (!zone) {
+          res.status(400).json({ success: false, error: 'deliveryZoneId does not belong to this tenant' })
+          return
+        }
+      }
+
+      const id = parseInt(String(req.params.id), 10)
+      const existingCliente = await prisma.cliente.findFirst({ where: { id, tenantId } })
+      if (!existingCliente) {
+        res.status(404).json({ success: false, error: 'Cliente not found' })
+        return
+      }
+
       const cliente = await prisma.cliente.update({
-        where: { id: parseInt(String(req.params.id), 10) },
+        where: { id },
         data,
       })
       await writeAudit(authReq, 'cliente_update', 'cliente', String(cliente.id))
@@ -890,9 +926,11 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/articulos', requirePermission('products.read'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const filtro = (req.query.q as string) || ''
       const articulos = await prisma.articulo.findMany({
         where: {
+          tenantId,
           OR: [
             { descripcion: { contains: filtro, mode: 'insensitive' } },
             { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
@@ -909,8 +947,9 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/articulos/:id', requirePermission('products.read'), async (req: Request, res: Response) => {
     try {
-      const articulo = await prisma.articulo.findUnique({
-        where: { id: parseInt(String(req.params.id), 10) },
+      const tenantId = getTenantId(req)
+      const articulo = await prisma.articulo.findFirst({
+        where: { id: parseInt(String(req.params.id), 10), tenantId },
         include: { rubro: true },
       })
       res.json({ success: true, data: articulo })
@@ -921,13 +960,21 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/articulos', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateArticuloInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
+      const rubro = await prisma.rubro.findFirst({
+        where: { id: parsed.value.rubroId, tenantId },
+      })
+      if (!rubro) {
+        res.status(400).json({ success: false, error: 'rubroId is not valid for this tenant' })
+        return
+      }
       const articulo = await prisma.articulo.create({
-        data: parsed.value,
+        data: { ...parsed.value, tenantId },
       })
       await writeAudit(req as AuthenticatedRequest, 'articulo_create', 'articulo', String(articulo.id))
       res.json({ success: true, data: articulo })
@@ -938,13 +985,27 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/articulos/:id', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateArticuloInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
+      const rubro = await prisma.rubro.findFirst({
+        where: { id: parsed.value.rubroId, tenantId },
+      })
+      if (!rubro) {
+        res.status(400).json({ success: false, error: 'rubroId is not valid for this tenant' })
+        return
+      }
+      const id = parseInt(String(req.params.id), 10)
+      const existing = await prisma.articulo.findFirst({ where: { id, tenantId } })
+      if (!existing) {
+        res.status(404).json({ success: false, error: 'Articulo not found' })
+        return
+      }
       const articulo = await prisma.articulo.update({
-        where: { id: parseInt(String(req.params.id), 10) },
+        where: { id },
         data: parsed.value,
       })
       await writeAudit(req as AuthenticatedRequest, 'articulo_update', 'articulo', String(articulo.id))
@@ -969,12 +1030,16 @@ export function createApp(prisma: PrismaClient): Application {
       return
     }
     try {
+          const tenantId = getTenantId(req)
           const parsedCsv = parseCsvWithFixedHeaders(file.buffer, ARTICULO_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
           if (!parsedCsv.ok) {
             res.status(400).json({ success: false, error: parsedCsv.error })
             return
           }
-          const rubrosDb = await prisma.rubro.findMany({ select: { id: true, codigo: true } })
+          const rubrosDb = await prisma.rubro.findMany({
+            where: { tenantId },
+            select: { id: true, codigo: true },
+          })
           const rubroByCodigo = new Map(rubrosDb.map((r) => [r.codigo, r.id]))
           const errors: { row: number; message: string }[] = []
           const seenCodigos = new Map<number, number>()
@@ -1016,7 +1081,7 @@ export function createApp(prisma: PrismaClient): Application {
             codigos.length === 0
               ? []
               : await prisma.articulo.findMany({
-                  where: { codigo: { in: codigos } },
+                  where: { tenantId, codigo: { in: codigos } },
                   select: { codigo: true },
                 })
           const existingSet = new Set(existing.map((e) => e.codigo))
@@ -1031,7 +1096,7 @@ export function createApp(prisma: PrismaClient): Application {
           let created = 0
           await prisma.$transaction(async (tx) => {
             for (const data of toInsert) {
-              await tx.articulo.create({ data })
+              await tx.articulo.create({ data: { ...data, tenantId } })
               created += 1
             }
           })
@@ -1052,9 +1117,11 @@ export function createApp(prisma: PrismaClient): Application {
 
   // ============ RUBROS ============
 
-  app.get('/api/rubros', requirePermission('products.read'), async (_req: Request, res: Response) => {
+  app.get('/api/rubros', requirePermission('products.read'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const rubros = await prisma.rubro.findMany({
+        where: { tenantId },
         orderBy: { codigo: 'asc' },
       })
       res.json({ success: true, data: rubros })
@@ -1065,12 +1132,13 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/rubros', requirePermission('products.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateRubroInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
-      const rubro = await prisma.rubro.create({ data: parsed.value })
+      const rubro = await prisma.rubro.create({ data: { ...parsed.value, tenantId } })
       await writeAudit(req as AuthenticatedRequest, 'rubro_create', 'rubro', String(rubro.id))
       res.json({ success: true, data: rubro })
     } catch (err: unknown) {
@@ -1093,6 +1161,7 @@ export function createApp(prisma: PrismaClient): Application {
       return
     }
     try {
+          const tenantId = getTenantId(req)
           const parsedCsv = parseCsvWithFixedHeaders(file.buffer, RUBRO_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
           if (!parsedCsv.ok) {
             res.status(400).json({ success: false, error: parsedCsv.error })
@@ -1126,7 +1195,7 @@ export function createApp(prisma: PrismaClient): Application {
             codigos.length === 0
               ? []
               : await prisma.rubro.findMany({
-                  where: { codigo: { in: codigos } },
+                  where: { tenantId, codigo: { in: codigos } },
                   select: { codigo: true },
                 })
           const existingSet = new Set(existing.map((e) => e.codigo))
@@ -1141,7 +1210,7 @@ export function createApp(prisma: PrismaClient): Application {
           let created = 0
           await prisma.$transaction(async (tx) => {
             for (const data of toInsert) {
-              await tx.rubro.create({ data })
+              await tx.rubro.create({ data: { ...data, tenantId } })
               created += 1
             }
           })
@@ -1164,9 +1233,11 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/proveedores', requirePermission('suppliers.read'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const filtro = (req.query.q as string) || ''
       const proveedores = await prisma.proveedor.findMany({
         where: {
+          tenantId,
           OR: [
             { rsocial: { contains: filtro, mode: 'insensitive' } },
             { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
@@ -1195,6 +1266,7 @@ export function createApp(prisma: PrismaClient): Application {
       return
     }
     try {
+          const tenantId = getTenantId(req)
           const parsedCsv = parseCsvWithFixedHeaders(file.buffer, PROVEEDOR_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
           if (!parsedCsv.ok) {
             res.status(400).json({ success: false, error: parsedCsv.error })
@@ -1228,7 +1300,7 @@ export function createApp(prisma: PrismaClient): Application {
             codigos.length === 0
               ? []
               : await prisma.proveedor.findMany({
-                  where: { codigo: { in: codigos } },
+                  where: { tenantId, codigo: { in: codigos } },
                   select: { codigo: true },
                 })
           const existingSet = new Set(existing.map((e) => e.codigo))
@@ -1243,7 +1315,7 @@ export function createApp(prisma: PrismaClient): Application {
           let created = 0
           await prisma.$transaction(async (tx) => {
             for (const data of toInsert) {
-              await tx.proveedor.create({ data })
+              await tx.proveedor.create({ data: { ...data, tenantId } })
               created += 1
             }
           })
@@ -1264,8 +1336,9 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.get('/api/proveedores/:id', requirePermission('suppliers.read'), async (req: Request, res: Response) => {
     try {
-      const proveedor = await prisma.proveedor.findUnique({
-        where: { id: parseInt(String(req.params.id), 10) },
+      const tenantId = getTenantId(req)
+      const proveedor = await prisma.proveedor.findFirst({
+        where: { id: parseInt(String(req.params.id), 10), tenantId },
       })
       res.json({ success: true, data: proveedor })
     } catch (err: unknown) {
@@ -1275,12 +1348,13 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/proveedores', requirePermission('suppliers.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateProveedorInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
-      const proveedor = await prisma.proveedor.create({ data: parsed.value })
+      const proveedor = await prisma.proveedor.create({ data: { ...parsed.value, tenantId } })
       await writeAudit(req as AuthenticatedRequest, 'proveedor_create', 'proveedor', String(proveedor.id))
       res.json({ success: true, data: proveedor })
     } catch (err: unknown) {
@@ -1290,13 +1364,20 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.put('/api/proveedores/:id', requirePermission('suppliers.manage'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateProveedorInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
         return
       }
+      const id = parseInt(String(req.params.id), 10)
+      const existing = await prisma.proveedor.findFirst({ where: { id, tenantId } })
+      if (!existing) {
+        res.status(404).json({ success: false, error: 'Proveedor not found' })
+        return
+      }
       const proveedor = await prisma.proveedor.update({
-        where: { id: parseInt(String(req.params.id), 10) },
+        where: { id },
         data: parsed.value,
       })
       await writeAudit(req as AuthenticatedRequest, 'proveedor_update', 'proveedor', String(proveedor.id))
@@ -1321,9 +1402,11 @@ export function createApp(prisma: PrismaClient): Application {
 
   // ============ FACTURAS ============
 
-  app.get('/api/facturas', requirePermission('reports.operational.read'), async (_req: Request, res: Response) => {
+  app.get('/api/facturas', requirePermission('reports.operational.read'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const facturas = await prisma.factura.findMany({
+        where: { tenantId },
         include: { cliente: true, items: true },
         orderBy: { fecha: 'desc' },
       })
@@ -1335,6 +1418,7 @@ export function createApp(prisma: PrismaClient): Application {
 
   app.post('/api/facturas', requirePermission('sales.create'), async (req: Request, res: Response) => {
     try {
+      const tenantId = getTenantId(req)
       const parsed = validateFacturaInput(req.body)
       if (!parsed.ok) {
         res.status(400).json({ success: false, error: parsed.error })
@@ -1343,12 +1427,26 @@ export function createApp(prisma: PrismaClient): Application {
       const { items, ...factura } = parsed.value
       const clienteId = factura.clienteId
 
+      const articuloIds = [...new Set(items.map((it) => it.articuloId))]
+      const articulosOk = await prisma.articulo.findMany({
+        where: { tenantId, id: { in: articuloIds } },
+        select: { id: true },
+      })
+      if (articulosOk.length !== articuloIds.length) {
+        res.status(400).json({ success: false, error: 'One or more articuloId values are not valid for this tenant' })
+        return
+      }
+
       // Check suspension before creating the factura
-      const clienteCheck = await prisma.cliente.findUnique({
-        where: { id: clienteId },
+      const clienteCheck = await prisma.cliente.findFirst({
+        where: { id: clienteId, tenantId },
         select: { suspended: true },
       })
-      if (clienteCheck?.suspended) {
+      if (!clienteCheck) {
+        res.status(400).json({ success: false, error: 'clienteId is not valid for this tenant' })
+        return
+      }
+      if (clienteCheck.suspended) {
         res.status(422).json({ success: false, error: 'CLIENT_SUSPENDED' })
         return
       }
@@ -1358,6 +1456,7 @@ export function createApp(prisma: PrismaClient): Application {
         const newFactura = await tx.factura.create({
           data: {
             ...factura,
+            tenantId,
             items: { create: items },
           } as Parameters<typeof prisma.factura.create>[0]['data'],
           include: { items: true },
@@ -1398,6 +1497,7 @@ export function createApp(prisma: PrismaClient): Application {
   app.put('/api/facturas/:id/void', requirePermission('sales.cancel'), async (req: Request, res: Response) => {
     try {
       const authReq = req as AuthenticatedRequest
+      const tenantId = getTenantId(req)
       const id = parseInt(String(req.params.id), 10)
       const { motivo } = req.body as { motivo?: string }
 
@@ -1407,7 +1507,7 @@ export function createApp(prisma: PrismaClient): Application {
       }
 
       const factura = await prisma.factura.findFirst({
-        where: { id },
+        where: { id, tenantId },
         select: { id: true, estado: true, total: true, clienteId: true },
       })
 

--- a/server/dashboard.ts
+++ b/server/dashboard.ts
@@ -49,16 +49,18 @@ export function registerDashboardRoutes(app: Application, prisma: PrismaClient):
       const thirtyDaysAgo = new Date(now)
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
 
+      const tenantId = authReq.auth.claims.tenantId
+
       const [ventasResult, vencidasResult] = await Promise.all([
         // Active invoices created today
         prisma.factura.aggregate({
-          where: { estado: 'A', fecha: { gte: todayStart, lte: todayEnd } },
+          where: { tenantId, estado: 'A', fecha: { gte: todayStart, lte: todayEnd } },
           _count: { id: true },
           _sum: { total: true },
         }),
         // Active invoices older than 30 days (overdue approximation)
         prisma.factura.aggregate({
-          where: { estado: 'A', fecha: { lt: thirtyDaysAgo } },
+          where: { tenantId, estado: 'A', fecha: { lt: thirtyDaysAgo } },
           _count: { id: true },
           _sum: { total: true },
         }),

--- a/tests/api/channels.test.ts
+++ b/tests/api/channels.test.ts
@@ -37,11 +37,12 @@ function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): Pris
     deliveryZone: { findMany: vi.fn().mockResolvedValue([]), findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue(null), update: vi.fn().mockResolvedValue(null) },
     cliente: {
       findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue({ id: 1, suspended: false }),
       findUnique: vi.fn().mockResolvedValue({ email: 'mgr@example.com', telef: '+5491155550000' }),
       create: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(null),
     },
-    articulo: { findMany: vi.fn().mockResolvedValue([]) },
+    articulo: { findMany: vi.fn().mockResolvedValue([{ id: 1 }]) },
     rubro: { findMany: vi.fn().mockResolvedValue([]) },
     formaPago: { findMany: vi.fn().mockResolvedValue([]) },
     factura: {
@@ -260,11 +261,12 @@ describe('POST /api/facturas — dispatchNotification failure is swallowed', () 
           const inner = buildPrismaMock({
             cliente: {
               findMany: vi.fn().mockResolvedValue([]),
-              findFirst: vi.fn().mockResolvedValue(null),
+              findFirst: vi.fn().mockResolvedValue({ id: 1, suspended: false }),
               findUnique: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(null),
               update: vi.fn().mockResolvedValue(updatedCliente),
             },
+            articulo: { findMany: vi.fn().mockResolvedValue([{ id: 1 }]) },
             factura: {
               findMany: vi.fn().mockResolvedValue([]),
               create: vi.fn().mockResolvedValue({ id: 99, total: 20000, items: [] }),

--- a/tests/api/clientes.test.ts
+++ b/tests/api/clientes.test.ts
@@ -57,13 +57,15 @@ const FACTURA_RESULT = {
 
 function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
   return {
+    deliveryZone: { findFirst: vi.fn().mockResolvedValue({ id: 1, tenantId: 1 }) },
     cliente: {
       findMany: vi.fn().mockResolvedValue([CLIENTE_BASE]),
+      findFirst: vi.fn().mockResolvedValue(CLIENTE_BASE),
       findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
       create: vi.fn().mockResolvedValue(CLIENTE_BASE),
       update: vi.fn().mockResolvedValue(CLIENTE_BASE),
     },
-    articulo: { findMany: vi.fn().mockResolvedValue([]) },
+    articulo: { findMany: vi.fn().mockResolvedValue([{ id: 1 }]) },
     rubro: { findMany: vi.fn().mockResolvedValue([]) },
     formaPago: { findMany: vi.fn().mockResolvedValue([]) },
     factura: {
@@ -119,6 +121,7 @@ describe('POST /api/facturas — cliente suspended', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(suspendedCliente),
         findUnique: vi.fn().mockResolvedValue(suspendedCliente),
         create: vi.fn(),
         update: vi.fn(),
@@ -141,6 +144,7 @@ describe('POST /api/facturas — cliente suspended', () => {
     const txPrisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(activeCliente),
         findUnique: vi.fn().mockResolvedValue(activeCliente),
         create: vi.fn(),
         update: vi.fn().mockResolvedValue({ id: 1, rsocial: 'ACME SA', balance: '1000.00', creditLimit: null }),
@@ -154,6 +158,7 @@ describe('POST /api/facturas — cliente suspended', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(activeCliente),
         findUnique: vi.fn().mockResolvedValue(activeCliente),
         create: vi.fn(),
         update: vi.fn().mockResolvedValue({ id: 1, rsocial: 'ACME SA', balance: '1000.00', creditLimit: null }),
@@ -202,6 +207,7 @@ describe('POST /api/facturas — balance update', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         create: vi.fn(),
         update: clienteUpdate,
@@ -251,6 +257,7 @@ describe('POST /api/facturas — credit limit notification', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         create: vi.fn(),
         update: clienteUpdate,
@@ -308,6 +315,7 @@ describe('POST /api/facturas — credit limit notification', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         create: vi.fn(),
         update: clienteUpdate,
@@ -347,6 +355,7 @@ describe('POST /api/facturas — credit limit notification', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         findUnique: vi.fn().mockResolvedValue({ ...CLIENTE_BASE, suspended: false }),
         create: vi.fn(),
         update: clienteUpdate,
@@ -387,6 +396,7 @@ describe('PUT /api/clientes/:id — financial field access', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(CLIENTE_BASE),
         findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
         create: vi.fn(),
         update: clienteUpdate,
@@ -420,6 +430,7 @@ describe('PUT /api/clientes/:id — financial field access', () => {
     const prisma = buildPrismaMock({
       cliente: {
         findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(CLIENTE_BASE),
         findUnique: vi.fn().mockResolvedValue(CLIENTE_BASE),
         create: vi.fn(),
         update: clienteUpdate,

--- a/tests/api/contract.test.ts
+++ b/tests/api/contract.test.ts
@@ -108,6 +108,7 @@ function buildPrisma(): PrismaClient {
   const proveedorTxCreate = vi.fn().mockResolvedValue(proveedorRow)
 
   const p = {
+    deliveryZone: { findFirst: vi.fn().mockResolvedValue(null) },
     cliente: {
       findMany: vi.fn((args?: unknown) => {
         const w =
@@ -119,6 +120,7 @@ function buildPrisma(): PrismaClient {
         }
         return Promise.resolve([clienteRow])
       }),
+      findFirst: vi.fn().mockResolvedValue(clienteRow),
       findUnique: vi.fn().mockResolvedValue(clienteRow),
       create: vi.fn().mockResolvedValue(clienteRow),
       update: vi.fn().mockResolvedValue(clienteRow), // PUT /api/clientes/:id returns full row
@@ -127,18 +129,26 @@ function buildPrisma(): PrismaClient {
       findMany: vi.fn((args?: unknown) => {
         const w =
           args && typeof args === 'object' && args !== null && 'where' in args
-            ? (args as { where?: { codigo?: { in?: number[] } } }).where
+            ? (args as {
+                where?: { codigo?: { in?: number[] }; id?: { in?: number[] } }
+              }).where
             : undefined
+        if (w?.id && typeof w.id === 'object' && Array.isArray(w.id.in)) {
+          if (w.id.in.length === 0) return Promise.resolve([])
+          return Promise.resolve(w.id.in.map((id: number) => ({ id })))
+        }
         if (w?.codigo && typeof w.codigo === 'object' && Array.isArray(w.codigo.in)) {
           return Promise.resolve([])
         }
         return Promise.resolve([articuloRow])
       }),
+      findFirst: vi.fn().mockResolvedValue(articuloRow),
       findUnique: vi.fn().mockResolvedValue(articuloRow),
       create: vi.fn().mockResolvedValue(articuloRow),
       update: vi.fn().mockResolvedValue(articuloRow),
     },
     rubro: {
+      findFirst: vi.fn().mockResolvedValue(rubroRow),
       findMany: vi.fn().mockImplementation((args?: unknown) => {
         const a =
           args && typeof args === 'object' && args !== null
@@ -174,6 +184,7 @@ function buildPrisma(): PrismaClient {
         }
         return Promise.resolve([proveedorRow])
       }),
+      findFirst: vi.fn().mockResolvedValue(proveedorRow),
       findUnique: vi.fn().mockResolvedValue(proveedorRow),
       create: vi.fn().mockResolvedValue(proveedorRow),
       update: vi.fn().mockResolvedValue(proveedorRow),
@@ -422,7 +433,7 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
 
   it('GET /api/clientes/:id', async () => {
     const p = buildPrisma()
-    vi.mocked(p.cliente.findUnique).mockRejectedValueOnce(err)
+    vi.mocked(p.cliente.findFirst).mockRejectedValueOnce(err)
     const res = await request(createApp(p)).get('/api/clientes/1').expect(500)
     await assertMatchesOpenApi('/api/clientes/{id}', 'get', '500', res.body)
   })
@@ -436,6 +447,7 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
 
   it('PUT /api/clientes/:id', async () => {
     const p = buildPrisma()
+    vi.mocked(p.cliente.findFirst).mockResolvedValueOnce(clienteRow as never)
     vi.mocked(p.cliente.update).mockRejectedValueOnce(err)
     const res = await request(createApp(p)).put('/api/clientes/1').send(clienteInput).expect(500)
     await assertMatchesOpenApi('/api/clientes/{id}', 'put', '500', res.body)
@@ -450,13 +462,14 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
 
   it('GET /api/articulos/:id', async () => {
     const p = buildPrisma()
-    vi.mocked(p.articulo.findUnique).mockRejectedValueOnce(err)
+    vi.mocked(p.articulo.findFirst).mockRejectedValueOnce(err)
     const res = await request(createApp(p)).get('/api/articulos/1').expect(500)
     await assertMatchesOpenApi('/api/articulos/{id}', 'get', '500', res.body)
   })
 
   it('POST /api/articulos', async () => {
     const p = buildPrisma()
+    vi.mocked(p.rubro.findFirst).mockResolvedValueOnce(rubroRow as never)
     vi.mocked(p.articulo.create).mockRejectedValueOnce(err)
     const res = await request(createApp(p)).post('/api/articulos').send(articuloInput).expect(500)
     await assertMatchesOpenApi('/api/articulos', 'post', '500', res.body)
@@ -464,6 +477,8 @@ describe('API — errores 500 (cobertura de ramas catch)', () => {
 
   it('PUT /api/articulos/:id', async () => {
     const p = buildPrisma()
+    vi.mocked(p.articulo.findFirst).mockResolvedValueOnce(articuloRow as never)
+    vi.mocked(p.rubro.findFirst).mockResolvedValueOnce(rubroRow as never)
     vi.mocked(p.articulo.update).mockRejectedValueOnce(err)
     const res = await request(createApp(p)).put('/api/articulos/1').send(articuloInput).expect(500)
     await assertMatchesOpenApi('/api/articulos/{id}', 'put', '500', res.body)

--- a/tests/api/proveedores.test.ts
+++ b/tests/api/proveedores.test.ts
@@ -50,6 +50,7 @@ function buildPrisma(overrides: Partial<Record<string, unknown>> = {}): PrismaCl
     rubro: { findMany: vi.fn().mockResolvedValue([]), create: vi.fn() },
     proveedor: {
       findMany: proveedorFindMany,
+      findFirst: vi.fn().mockResolvedValue(proveedorRow),
       findUnique: vi.fn().mockResolvedValue(proveedorRow),
       create: vi.fn().mockResolvedValue(proveedorRow),
       update: vi.fn().mockResolvedValue(proveedorRow),

--- a/tests/fixtures/catalogFactories.ts
+++ b/tests/fixtures/catalogFactories.ts
@@ -8,12 +8,13 @@ import type { PrismaClient } from '@prisma/client'
 /** Creates a rubro row; use before creating articulos that require rubroId. */
 export async function createIntegrationRubro(
   prisma: PrismaClient,
-  overrides: Partial<{ codigo: number; nombre: string }> = {},
+  overrides: Partial<{ codigo: number; nombre: string; tenantId: number }> = {},
 ) {
+  const tenantId = overrides.tenantId ?? 1
   const codigo = overrides.codigo ?? 9001
   const nombre = (overrides.nombre ?? 'Rubro int test').slice(0, 20)
   return prisma.rubro.create({
-    data: { codigo, nombre },
+    data: { tenantId, codigo, nombre },
   })
 }
 

--- a/tests/integration/api.integration.test.ts
+++ b/tests/integration/api.integration.test.ts
@@ -18,9 +18,19 @@ async function truncateAll(prisma: PrismaClient): Promise<void> {
     prisma.articulo.deleteMany(),
     prisma.cliente.deleteMany(),
     prisma.rubro.deleteMany(),
+    prisma.proveedor.deleteMany(),
     prisma.formaPago.deleteMany(),
     prisma.paramEmpresa.deleteMany(),
   ])
+}
+
+/** Ensures row id=1 exists for BIZCODE_TEST_AUTH_BYPASS (see server/auth.ts). */
+async function ensureBypassTenant(prisma: PrismaClient): Promise<void> {
+  await prisma.tenant.upsert({
+    where: { id: 1 },
+    create: { id: 1, name: 'Integration tenant', slug: 'integration-tenant-1', active: true },
+    update: { active: true },
+  })
 }
 
 describe('API — integración PostgreSQL (Prisma real)', () => {
@@ -39,6 +49,7 @@ describe('API — integración PostgreSQL (Prisma real)', () => {
     prisma = new PrismaClient()
     app = createApp(prisma)
     await prisma.$connect()
+    await ensureBypassTenant(prisma)
   })
 
   afterAll(async () => {
@@ -119,5 +130,28 @@ describe('API — integración PostgreSQL (Prisma real)', () => {
     expect(Array.isArray(res.body.data)).toBe(true)
     const codes = (res.body.data as { codigo: number }[]).map((r) => r.codigo)
     expect(codes).toContain(9202)
+  })
+
+  it('no expone entidades de otro tenant en listados y lecturas por id', async () => {
+    const other = await prisma.tenant.create({
+      data: { name: 'Tenant B', slug: `tenant-b-${Date.now()}`, active: true },
+    })
+    const otherCliente = await prisma.cliente.create({
+      data: {
+        tenantId: other.id,
+        codigo: 66001,
+        rsocial: 'Cliente otro tenant SA'.slice(0, 30),
+        condIva: 'RI',
+        activo: true,
+      },
+    })
+
+    const listRes = await request(app).get('/api/clientes').expect(200)
+    expect(listRes.body.success).toBe(true)
+    expect((listRes.body.data as { id: number }[]).some((c) => c.id === otherCliente.id)).toBe(false)
+
+    const getRes = await request(app).get(`/api/clientes/${otherCliente.id}`).expect(200)
+    expect(getRes.body.success).toBe(true)
+    expect(getRes.body.data).toBeNull()
   })
 })

--- a/tests/integration/dbf-migration.integration.test.ts
+++ b/tests/integration/dbf-migration.integration.test.ts
@@ -62,6 +62,12 @@ describe('DBF migration integration', () => {
     process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
     prisma = new PrismaClient()
     await prisma.$connect()
+    const t = await prisma.tenant.upsert({
+      where: { slug: 'dbf-migration-test' },
+      create: { name: 'DBF migration test', slug: 'dbf-migration-test', active: true },
+      update: {},
+    })
+    process.env.BIZCODE_MIGRATION_TENANT_ID = String(t.id)
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'bizcode-dbf-'))
     await createFixtureDbfTree(fixtureRoot)
   })
@@ -79,12 +85,13 @@ describe('DBF migration integration', () => {
     process.env.PROGRAMA_VIEJO_ROOT = fixtureRoot
     await runDbfMigration()
 
+    const tenantId = parseInt(process.env.BIZCODE_MIGRATION_TENANT_ID ?? '0', 10)
     const placeholders = await prisma.cliente.findMany({
-      where: { codigo: { gte: 91001, lte: 91010 } },
+      where: { tenantId, codigo: { gte: 91001, lte: 91010 } },
     })
     expect(placeholders).toHaveLength(10)
 
-    const importedProducts = await prisma.articulo.findMany()
+    const importedProducts = await prisma.articulo.findMany({ where: { tenantId } })
     expect(importedProducts.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Linked IssueCloses #83
Relates to #80 (duplicado; cerrar o marcar como duplicado al fusionar).

## Qué cambia- Migración Prisma: \	enantId\ en Cliente, Rubro, Articulo, Proveedor, Factura; unicidad compuesta por tenant; backfill al \MIN(Tenant.id)\.
- API: filtros y creates con \eq.auth.claims.tenantId\; validación de rubro/zona de entrega; facturas validan artículos y cliente del tenant.
- Dashboard: agregados de facturas filtrados por tenant.
- Seed / \migrate-from-dbf\: soporte \BIZCODE_MIGRATION_TENANT_ID\; rubro fixture por tenant.
- Tests: integración aislamiento + ajuste mocks; \.env.example\.

## Verificación local
- \
pm run lint\
- \
pm run type-check\
- \
pm run test\ (344 tests)
- \
px prisma migrate deploy\ en BD limpia (si una BD local quedó a medias, resolver con backup o \prisma migrate resolve\ según doc Prisma).

## Riesgo
Migración destructiva de índices únicos; revisar datos existentes antes de producción.

Made with [Cursor](https://cursor.com)