### PR TITLE
fix(api): validación server-side zonas de entrega y anulación de facturas

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1820,6 +1820,7 @@ components:
         motivo:
           type: string
           minLength: 1
+          maxLength: 500
           description: Reason for voiding the invoice. Stored in AuditEvent metadata.
 
     FacturaInput:

--- a/docs/generated/schema-json/VoidInput.schema.json
+++ b/docs/generated/schema-json/VoidInput.schema.json
@@ -3,6 +3,7 @@
   "properties": {
     "motivo": {
       "description": "Reason for voiding the invoice. Stored in AuditEvent metadata.",
+      "maxLength": 500,
       "minLength": 1,
       "type": "string"
     }

--- a/docs/generated/schema-md/voidinput-properties-motivo.md
+++ b/docs/generated/schema-md/voidinput-properties-motivo.md
@@ -16,4 +16,6 @@ Reason for voiding the invoice. Stored in AuditEvent metadata.
 
 ## motivo Constraints
 
+**maximum length**: the maximum number of characters for this string is: `500`
+
 **minimum length**: the minimum number of characters for this string is: `1`

--- a/docs/generated/schema-md/voidinput.md
+++ b/docs/generated/schema-md/voidinput.md
@@ -40,4 +40,6 @@ Reason for voiding the invoice. Stored in AuditEvent metadata.
 
 ### motivo Constraints
 
+**maximum length**: the maximum number of characters for this string is: `500`
+
 **minimum length**: the minimum number of characters for this string is: `1`

--- a/server/createApp.ts
+++ b/server/createApp.ts
@@ -394,6 +394,112 @@ function validateFacturaInput(raw: unknown): ValidationResult<FacturaInput> {
   }
 }
 
+/** @en Max length for invoice void reason (audit metadata). @es Máx. motivo anulación. @pt-BR Máx. motivo anulação. */
+const FACTURA_VOID_MOTIVO_MAX_LEN = 500
+
+type FacturaVoidBody = { motivo: string }
+
+function validateFacturaVoidBody(raw: unknown): ValidationResult<FacturaVoidBody> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  if (typeof raw.motivo !== 'string') return { ok: false, error: 'motivo must be a string' }
+  const motivo = raw.motivo.trim()
+  if (motivo.length < 1) return { ok: false, error: 'motivo is required' }
+  if (motivo.length > FACTURA_VOID_MOTIVO_MAX_LEN) {
+    return { ok: false, error: `motivo must be at most ${FACTURA_VOID_MOTIVO_MAX_LEN} characters` }
+  }
+  return { ok: true, value: { motivo } }
+}
+
+type DeliveryZoneCreateBody = {
+  nombre: string
+  tipo: 'barrio' | 'manual' | 'predefinida'
+  diasEntrega: string | null
+  horario: string | null
+}
+
+function validateDeliveryZoneCreateBody(raw: unknown): ValidationResult<DeliveryZoneCreateBody> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  if (typeof raw.nombre !== 'string') return { ok: false, error: 'nombre must be a string' }
+  const nombre = raw.nombre.trim()
+  if (nombre.length < 1 || nombre.length > 60) {
+    return { ok: false, error: 'nombre must be between 1 and 60 characters' }
+  }
+  let tipo: DeliveryZoneCreateBody['tipo'] = 'barrio'
+  if (raw.tipo !== undefined) {
+    if (typeof raw.tipo !== 'string' || !['barrio', 'manual', 'predefinida'].includes(raw.tipo)) {
+      return { ok: false, error: 'tipo must be one of: barrio, manual, predefinida' }
+    }
+    tipo = raw.tipo as DeliveryZoneCreateBody['tipo']
+  }
+  const diasEntrega = parseOptionalString(raw.diasEntrega, 20, 'diasEntrega')
+  if (!diasEntrega.ok) return diasEntrega
+  const horario = parseOptionalString(raw.horario, 30, 'horario')
+  if (!horario.ok) return horario
+  return {
+    ok: true,
+    value: {
+      nombre,
+      tipo,
+      diasEntrega: diasEntrega.value === undefined ? null : diasEntrega.value,
+      horario: horario.value === undefined ? null : horario.value,
+    },
+  }
+}
+
+type DeliveryZoneUpdateBody = {
+  nombre?: string
+  tipo?: 'barrio' | 'manual' | 'predefinida'
+  diasEntrega?: string | null
+  horario?: string | null
+  activo?: boolean
+}
+
+function validateDeliveryZoneUpdateBody(raw: unknown): ValidationResult<DeliveryZoneUpdateBody> {
+  if (!isObjectRecord(raw)) return { ok: false, error: 'Request body must be an object' }
+  const out: DeliveryZoneUpdateBody = {}
+  if (raw.nombre !== undefined) {
+    if (typeof raw.nombre !== 'string') return { ok: false, error: 'nombre must be a string' }
+    const n = raw.nombre.trim()
+    if (n.length < 1 || n.length > 60) {
+      return { ok: false, error: 'nombre must be between 1 and 60 characters' }
+    }
+    out.nombre = n
+  }
+  if (raw.tipo !== undefined) {
+    if (typeof raw.tipo !== 'string' || !['barrio', 'manual', 'predefinida'].includes(raw.tipo)) {
+      return { ok: false, error: 'tipo must be one of: barrio, manual, predefinida' }
+    }
+    out.tipo = raw.tipo as DeliveryZoneUpdateBody['tipo']
+  }
+  if (raw.diasEntrega !== undefined) {
+    if (raw.diasEntrega === null) {
+      out.diasEntrega = null
+    } else if (typeof raw.diasEntrega !== 'string') {
+      return { ok: false, error: 'diasEntrega must be a string or null' }
+    } else {
+      const t = raw.diasEntrega.trim()
+      if (t.length > 20) return { ok: false, error: 'diasEntrega must be at most 20 characters' }
+      out.diasEntrega = t.length === 0 ? null : t
+    }
+  }
+  if (raw.horario !== undefined) {
+    if (raw.horario === null) {
+      out.horario = null
+    } else if (typeof raw.horario !== 'string') {
+      return { ok: false, error: 'horario must be a string or null' }
+    } else {
+      const t = raw.horario.trim()
+      if (t.length > 30) return { ok: false, error: 'horario must be at most 30 characters' }
+      out.horario = t.length === 0 ? null : t
+    }
+  }
+  if (raw.activo !== undefined) {
+    if (typeof raw.activo !== 'boolean') return { ok: false, error: 'activo must be a boolean' }
+    out.activo = raw.activo
+  }
+  return { ok: true, value: out }
+}
+
 const CLIENTE_IMPORT_CSV_HEADERS = [
   'codigo',
   'rsocial',
@@ -1499,12 +1605,12 @@ export function createApp(prisma: PrismaClient): Application {
       const authReq = req as AuthenticatedRequest
       const tenantId = getTenantId(req)
       const id = parseInt(String(req.params.id), 10)
-      const { motivo } = req.body as { motivo?: string }
-
-      if (!motivo?.trim()) {
-        res.status(400).json({ success: false, error: 'motivo is required' })
+      const voidParsed = validateFacturaVoidBody(req.body)
+      if (!voidParsed.ok) {
+        res.status(400).json({ success: false, error: voidParsed.error })
         return
       }
+      const { motivo } = voidParsed.value
 
       const factura = await prisma.factura.findFirst({
         where: { id, tenantId },
@@ -1534,7 +1640,7 @@ export function createApp(prisma: PrismaClient): Application {
         return voided
       })
 
-      await writeAudit(authReq, 'factura_void', 'factura', String(id), { motivo: motivo.trim() })
+      await writeAudit(authReq, 'factura_void', 'factura', String(id), { motivo })
       res.json({ success: true, data: updated })
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
@@ -1561,18 +1667,14 @@ export function createApp(prisma: PrismaClient): Application {
     try {
       const authReq = req as AuthenticatedRequest
       const tenantId = authReq.auth!.claims.tenantId
-      const { nombre, tipo, diasEntrega, horario } = req.body as {
-        nombre?: string
-        tipo?: string
-        diasEntrega?: string
-        horario?: string
-      }
-      if (!nombre?.trim()) {
-        res.status(400).json({ success: false, error: 'nombre is required' })
+      const parsed = validateDeliveryZoneCreateBody(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
         return
       }
+      const { nombre, tipo, diasEntrega, horario } = parsed.value
       const zone = await prisma.deliveryZone.create({
-        data: { tenantId, nombre: nombre.trim(), tipo: tipo ?? 'barrio', diasEntrega, horario },
+        data: { tenantId, nombre, tipo, diasEntrega, horario },
       })
       await writeAudit(authReq, 'delivery_zone_create', 'delivery_zone', String(zone.id))
       res.status(201).json({ success: true, data: zone })
@@ -1594,17 +1696,16 @@ export function createApp(prisma: PrismaClient): Application {
         return
       }
 
-      const { nombre, tipo, diasEntrega, horario, activo } = req.body as {
-        nombre?: string
-        tipo?: string
-        diasEntrega?: string
-        horario?: string
-        activo?: boolean
+      const parsed = validateDeliveryZoneUpdateBody(req.body)
+      if (!parsed.ok) {
+        res.status(400).json({ success: false, error: parsed.error })
+        return
       }
+      const { nombre, tipo, diasEntrega, horario, activo } = parsed.value
       const zone = await prisma.deliveryZone.update({
         where: { id },
         data: {
-          ...(nombre !== undefined && { nombre: nombre.trim() }),
+          ...(nombre !== undefined && { nombre }),
           ...(tipo !== undefined && { tipo }),
           ...(diasEntrega !== undefined && { diasEntrega }),
           ...(horario !== undefined && { horario }),

--- a/tests/api/facturas-void.test.ts
+++ b/tests/api/facturas-void.test.ts
@@ -139,6 +139,32 @@ describe('PUT /api/facturas/:id/void', () => {
     expect(res.body.success).toBe(false)
   })
 
+  it('returns 400 when motivo is not a string', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .put('/api/facturas/1/void')
+      .send({ motivo: 123 })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(String(res.body.error)).toMatch(/motivo/)
+  })
+
+  it('returns 400 when motivo exceeds max length', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .put('/api/facturas/1/void')
+      .send({ motivo: 'x'.repeat(501) })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(String(res.body.error)).toMatch(/at most 500/)
+  })
+
   it('returns 404 when factura does not belong to tenant', async () => {
     const prisma = buildPrismaMock({
       factura: {

--- a/tests/api/request-validation.test.ts
+++ b/tests/api/request-validation.test.ts
@@ -110,5 +110,13 @@ describe('API payload validation on POST/PUT business routes', () => {
     expect(res.body.success).toBe(false)
     expect(vi.mocked(prisma.factura.create)).not.toHaveBeenCalled()
   })
+
+  it('returns 400 for invalid POST /api/zonas-entrega payload', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/zonas-entrega').send({ nombre: '', tipo: 'barrio' }).expect(400)
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.deliveryZone.create)).not.toHaveBeenCalled()
+  })
 })
 

--- a/tests/api/zonas-entrega.test.ts
+++ b/tests/api/zonas-entrega.test.ts
@@ -151,6 +151,33 @@ describe('POST /api/zonas-entrega', () => {
     expect(res.body.error).toMatch(/nombre/)
   })
 
+  it('returns 400 when tipo is invalid on create', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .post('/api/zonas-entrega')
+      .send({ nombre: 'Zona', tipo: 'invalid' })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(String(res.body.error)).toMatch(/tipo/)
+    expect(vi.mocked(prisma.deliveryZone.create)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when nombre exceeds max length on create', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .post('/api/zonas-entrega')
+      .send({ nombre: 'n'.repeat(61) })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.deliveryZone.create)).not.toHaveBeenCalled()
+  })
+
   it('returns 403 for logistics_planner (has logistics.manage)', async () => {
     // logistics_planner has logistics.manage — should succeed
     process.env.BIZCODE_TEST_ROLE = 'logistics_planner'
@@ -195,6 +222,33 @@ describe('PUT /api/zonas-entrega/:id', () => {
     expect(res.body.success).toBe(true)
     expect(res.body.data.nombre).toBe('Barrio Norte Actualizado')
     expect(res.body.data.activo).toBe(false)
+  })
+
+  it('returns 400 when tipo is invalid on update', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .put('/api/zonas-entrega/10')
+      .send({ tipo: 'not-an-enum' })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(String(res.body.error)).toMatch(/tipo/)
+    expect(vi.mocked(prisma.deliveryZone.update)).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when nombre is empty string on update', async () => {
+    const prisma = buildPrismaMock()
+    const app = createApp(prisma)
+
+    const res = await request(app)
+      .put('/api/zonas-entrega/10')
+      .send({ nombre: '  ' })
+      .expect(400)
+
+    expect(res.body.success).toBe(false)
+    expect(vi.mocked(prisma.deliveryZone.update)).not.toHaveBeenCalled()
   })
 
   it('returns 404 when zone does not belong to the tenant', async () => {


### PR DESCRIPTION
## Resumen
Alinea la validación de \POST/PUT /api/zonas-entrega\ y \PUT /api/facturas/:id/void\ con OpenAPI y con los esquemas Zod del frontend (tipos de zona, longitudes).

## Cambios
- \alidateDeliveryZoneCreateBody\ / \alidateDeliveryZoneUpdateBody\: \
ombre\1–60, \	ipo\ enum, \diasEntrega\ / \horario\ con límites y tipos correctos.
- \alidateFacturaVoidBody\: \motivo\ string no vacío, máximo 500 caracteres (también en \VoidInput\ en OpenAPI).
- Pruebas API ampliadas en \acturas-void.test.ts\, \zonas-entrega.test.ts\, \equest-validation.test.ts\.

## Verificación local
- \
pm run lint\
- \
pm run type-check\
- \
pm run test\ (351 tests)

Relacionado con el backlog de validación server-side (\docs/referencias/10-plan-implementaciones-futuras-bizcode.md\).

Made with [Cursor](https://cursor.com)