### PR TITLE
test(e2e): cliente con data-testid estables y spec BP1-2 (#66)

### DIFF
--- a/docs/evidence/sbom-cyclonedx.json
+++ b/docs/evidence/sbom-cyclonedx.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "version": 1,
-  "serialNumber": "urn:uuid:40538c93-4937-419e-9c18-d14a5534e06a",
+  "serialNumber": "urn:uuid:b59c4096-7cd7-4680-833f-da2a11e85d7f",
   "metadata": {
-    "timestamp": "2026-04-18T21:48:21.686Z",
+    "timestamp": "2026-04-18T23:35:55.627Z",
     "tools": {
       "components": [
         {

--- a/e2e/critical-paths.spec.ts
+++ b/e2e/critical-paths.spec.ts
@@ -63,61 +63,27 @@ test.describe('Critical Paths — Core Business Workflows', () => {
     await expect(page.locator('#root')).toBeVisible()
   })
 
-  // Test 5: Full workflow — Create cliente
+  // Test 5: Full workflow — Create cliente (stable data-testid selectors, BP1-2 / #66)
   test('Create a new cliente (customer)', async ({ page }) => {
     await loginAsTestUser(page, TEST_PASSWORD)
 
-    const id = generateId()
-    const testCliente = {
-      codigo: generateNumericCodigo(),
-      razonSocial: `Test Cliente ${id}`,
-      cuit: '20123456789', // Valid CUIT format (fake)
-      email: `test-${id}@example.com`,
-      telefono: '+5491123456789',
-      domicilio: 'Calle Falsa 123',
-    }
+    const codigo = generateNumericCodigo()
+    const razonSocial = `E2E Cliente ${generateId()}`
 
     await page.goto('/clientes', { waitUntil: 'networkidle' })
 
-    // Wait for page to load
-    await page.waitForTimeout(500)
+    await page.getByTestId('btn-nuevo-cliente').click()
+    await expect(page.getByTestId('cliente-form-dialog')).toBeVisible()
+    await expect(page.getByTestId('cliente-form')).toBeVisible()
 
-    // Try to find create button or form trigger
-    // Button might be F3 keyboard shortcut or a visible button
-    const createButton = page.locator('button:has-text("Nuevo"), button:has-text("Nueva"), [aria-label*="Nuevo"]').first()
+    await page.getByTestId('cliente-form-codigo').fill(String(codigo))
+    await page.getByTestId('cliente-form-rsocial').fill(razonSocial)
 
-    if (await createButton.isVisible()) {
-      await createButton.click()
-    } else {
-      // Try keyboard shortcut F3
-      await page.keyboard.press('F3')
-    }
+    await page.getByTestId('btn-save-cliente').click()
 
-    // Wait for form to appear
-    await page.waitForTimeout(300)
-
-    // Fill in form fields (adjust selectors based on actual HTML)
-    const codigoInput = page.locator('input[placeholder*="Código"], input[name="codigo"]').first()
-    const nombreInput = page.locator('input[placeholder*="Razón Social"], input[name="razonSocial"]').first()
-
-    if (await codigoInput.isVisible()) {
-      await codigoInput.fill(String(testCliente.codigo))
-    }
-
-    if (await nombreInput.isVisible()) {
-      await nombreInput.fill(testCliente.razonSocial)
-    }
-
-    // Try to save with F5 or button click
-    await page.keyboard.press('F5')
-
-    // Wait for save to complete
-    await page.waitForTimeout(500)
-
-    // Verify success (check for toast/notification or data in table)
-    // This is a basic check — adjust based on actual success indicators
-    const errorMessage = page.locator('[role="alert"]').filter({ hasText: 'Error' })
-    expect(await errorMessage.isVisible()).toBe(false)
+    await expect(page.getByTestId('cliente-form-dialog')).toBeHidden({ timeout: 20_000 })
+    await expect(page.getByTestId('clientes-table')).toBeVisible()
+    await expect(page.locator('[data-testid="clientes-table"] tbody tr').filter({ hasText: razonSocial })).toBeVisible()
   })
 
   // Test 6: Full workflow — Create artículo

--- a/src/pages/clientes/ClienteForm.tsx
+++ b/src/pages/clientes/ClienteForm.tsx
@@ -28,8 +28,13 @@ const clienteSchema = z.object({
   creditLimit: z.coerce.number().positive().optional().nullable(),
   creditDays: z.coerce.number().int().min(0).optional(),
   suspended: z.boolean().optional(),
-  // Logistics (Issue #32)
-  deliveryZoneId: z.coerce.number().int().positive().optional().nullable(),
+  // Logistics (Issue #32) — HTML <select value=""> must not coerce to 0 (would fail .positive() and block submit silently).
+  deliveryZoneId: z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined
+    const n = typeof val === 'number' ? val : Number(val)
+    if (!Number.isFinite(n) || n <= 0) return undefined
+    return Math.trunc(n)
+  }, z.number().int().positive().optional().nullable()),
 })
 
 type ClienteFormData = z.infer<typeof clienteSchema>

--- a/src/pages/clientes/ClienteForm.tsx
+++ b/src/pages/clientes/ClienteForm.tsx
@@ -128,6 +128,7 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
       role="dialog"
       aria-modal="true"
       aria-labelledby="dialog-cliente-title"
+      data-testid="cliente-form-dialog"
     >
       <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div className="bg-slate-200 dark:bg-slate-700 px-6 py-4 border-b border-slate-300 dark:border-slate-600">
@@ -137,7 +138,7 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
           <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">{t('form.hint')}</p>
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-4" data-testid="cliente-form">
           {error && (
             <div role="alert" className="p-3 bg-red-100 dark:bg-red-900 text-red-900 dark:text-red-100 rounded border border-red-300 dark:border-red-700">
               {error}
@@ -151,6 +152,7 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
             <input
               id="cliente-codigo"
               type="number"
+              data-testid="cliente-form-codigo"
               {...register('codigo')}
               aria-required="true"
               aria-describedby={errors.codigo ? 'cliente-codigo-error' : undefined}
@@ -169,6 +171,7 @@ export default function ClienteForm({ cliente, onClose, onGuardado }: ClienteFor
             <input
               id="cliente-rsocial"
               type="text"
+              data-testid="cliente-form-rsocial"
               {...register('rsocial')}
               maxLength={30}
               aria-required="true"

--- a/src/pages/clientes/index.tsx
+++ b/src/pages/clientes/index.tsx
@@ -177,6 +177,7 @@ export default function ClientesPage() {
         ) : (
           <table
             ref={tableRef}
+            data-testid="clientes-table"
             aria-label={t('title')}
             className="w-full border-collapse bg-white dark:bg-slate-800 rounded overflow-hidden border border-slate-200 dark:border-slate-700"
           >


### PR DESCRIPTION
## Resumen
- Añade \data-testid\ estables en \ClienteForm\ y tabla de clientes para E2E determinista.
- Actualiza el test Playwright de crear cliente para usar \getByTestId\ y validar fila en tabla.

## Verificación local
- \
pm run lint\
- \
pm run type-check\
- \
pm run test\

Closes #66

Made with [Cursor](https://cursor.com)