### PR TITLE
test(e2e): artículo estable + rubro de catálogo en seed CI (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
           echo "::add-mask::$E2E_PW"
 
       - name: Seed database for E2E (SuperAdmin login)
+        env:
+          BIZCODE_SEED_FIXTURE_CATALOG: 'true'
         run: npx prisma db seed
 
       - name: Start API for E2E (background)

--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -138,6 +138,8 @@ jobs:
           echo "::add-mask::$E2E_PW"
 
       - name: Prisma migrate and seed (E2E needs API + SuperAdmin)
+        env:
+          BIZCODE_SEED_FIXTURE_CATALOG: 'true'
         run: |
           npx prisma generate
           npx prisma migrate deploy

--- a/.github/workflows/qa-validation.yml
+++ b/.github/workflows/qa-validation.yml
@@ -166,6 +166,7 @@ jobs:
       - name: Prisma generate, migrate, seed
         env:
           DATABASE_URL: postgresql://test@localhost:5432/bizcode_test?sslmode=disable
+          BIZCODE_SEED_FIXTURE_CATALOG: 'true'
         run: |
           npx prisma generate
           npx prisma migrate deploy

--- a/docs/evidence/sbom-cyclonedx.json
+++ b/docs/evidence/sbom-cyclonedx.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "version": 1,
-  "serialNumber": "urn:uuid:510793a2-e8e7-4365-86cc-182b97062461",
+  "serialNumber": "urn:uuid:52e5735e-28f7-4bff-af1d-32c3a09d1a4b",
   "metadata": {
-    "timestamp": "2026-04-19T00:16:02.607Z",
+    "timestamp": "2026-04-19T00:23:15.640Z",
     "tools": {
       "components": [
         {

--- a/docs/evidence/sbom-cyclonedx.json
+++ b/docs/evidence/sbom-cyclonedx.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "version": 1,
-  "serialNumber": "urn:uuid:b59c4096-7cd7-4680-833f-da2a11e85d7f",
+  "serialNumber": "urn:uuid:510793a2-e8e7-4365-86cc-182b97062461",
   "metadata": {
-    "timestamp": "2026-04-18T23:35:55.627Z",
+    "timestamp": "2026-04-19T00:16:02.607Z",
     "tools": {
       "components": [
         {

--- a/e2e/critical-paths.spec.ts
+++ b/e2e/critical-paths.spec.ts
@@ -86,50 +86,36 @@ test.describe('Critical Paths — Core Business Workflows', () => {
     await expect(page.locator('[data-testid="clientes-table"] tbody tr').filter({ hasText: razonSocial })).toBeVisible()
   })
 
-  // Test 6: Full workflow — Create artículo
+  // Test 6: Full workflow — Create artículo (stable data-testid selectors, BP1-2 / #66)
   test('Create a new artículo (product)', async ({ page }) => {
     await loginAsTestUser(page, TEST_PASSWORD)
     const id = generateId()
-    const testArticulo = {
-      codigo: generateNumericCodigo(),
-      descripcion: `Test Articulo ${id}`,
-      precioLista: '100.00',
-      costo: '50.00',
-      stock: '10',
-    }
+    const codigo = generateNumericCodigo()
+    const descripcion = `E2E Artículo ${id}`
 
     await page.goto('/articulos', { waitUntil: 'networkidle' })
-    await page.waitForTimeout(500)
 
-    // Try to create new articulo
-    const createButton = page.locator('button:has-text("Nuevo"), button:has-text("Nueva")').first()
-    if (await createButton.isVisible()) {
-      await createButton.click()
-    } else {
-      await page.keyboard.press('F3')
-    }
+    await page.getByTestId('btn-nuevo-articulo').click()
+    await expect(page.getByTestId('articulo-form-dialog')).toBeVisible()
+    await expect(page.getByTestId('articulo-form')).toBeVisible()
 
-    await page.waitForTimeout(300)
+    await page.getByTestId('articulo-form-codigo').fill(String(codigo))
+    await page.getByTestId('articulo-form-descripcion').fill(descripcion)
 
-    // Fill form fields
-    const codigoInput = page.locator('input[placeholder*="Código"], input[name="codigo"]').first()
-    const descripcionInput = page.locator('input[placeholder*="Descripción"], input[name="descripcion"]').first()
+    const rubroSelect = page.getByTestId('articulo-form-rubroId')
+    await expect(rubroSelect.locator('option')).not.toHaveCount(1)
+    await rubroSelect.selectOption({ index: 1 })
 
-    if (await codigoInput.isVisible()) {
-      await codigoInput.fill(String(testArticulo.codigo))
-    }
+    await page.getByTestId('articulo-form-precioLista1').fill('100.00')
+    await page.getByTestId('articulo-form-precioLista2').fill('95.00')
+    await page.getByTestId('articulo-form-costo').fill('50.00')
+    await page.getByTestId('articulo-form-stock').fill('10')
 
-    if (await descripcionInput.isVisible()) {
-      await descripcionInput.fill(testArticulo.descripcion)
-    }
+    await page.getByTestId('btn-save-articulo').click()
 
-    // Save
-    await page.keyboard.press('F5')
-    await page.waitForTimeout(500)
-
-    // Verify no errors
-    const errorMessage = page.locator('[role="alert"]').filter({ hasText: 'Error' })
-    expect(await errorMessage.isVisible()).toBe(false)
+    await expect(page.getByTestId('articulo-form-dialog')).toBeHidden({ timeout: 20_000 })
+    await expect(page.getByTestId('articulos-table')).toBeVisible()
+    await expect(page.locator('[data-testid="articulos-table"] tbody tr').filter({ hasText: descripcion })).toBeVisible()
   })
 
   // Test 7: Full workflow — Create factura
@@ -266,7 +252,7 @@ test.describe('Critical Paths — Data Validation', () => {
     await page.keyboard.press('F3')
     await page.waitForTimeout(300)
 
-    const precioInput = page.locator('input[placeholder*="Precio"], input[name="precio"]').first()
+    const precioInput = page.getByTestId('articulo-form-precioLista1')
 
     if (await precioInput.isVisible()) {
       // Try negative price

--- a/src/pages/articulos/ArticuloForm.tsx
+++ b/src/pages/articulos/ArticuloForm.tsx
@@ -52,7 +52,8 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
     resolver: zodResolver(articuloSchema) as any,
     defaultValues: (articulo || {
       condIva: '1',
-      umedida: 'U',
+      // Must be length ≥2 (zod + server/createApp.ts); single "U" blocked submit without surfacing umedida in E2E.
+      umedida: 'UN',
       minimo: 0,
       activo: true,
     }) as ArticuloFormData,

--- a/src/pages/articulos/ArticuloForm.tsx
+++ b/src/pages/articulos/ArticuloForm.tsx
@@ -10,7 +10,13 @@ import { Articulo, Rubro } from '@/types'
 const articuloSchema = z.object({
   codigo: z.coerce.number().int().positive('Código debe ser positivo'),
   descripcion: z.string().min(3, 'Mínimo 3 caracteres').max(30),
-  rubroId: z.coerce.number().int().positive('Seleccione un rubro'),
+  // Rubro — HTML <select value=""> must not coerce to 0 (would fail .positive() and block submit).
+  rubroId: z.preprocess((val) => {
+    if (val === '' || val === null || val === undefined) return undefined
+    const n = typeof val === 'number' ? val : Number(val)
+    if (!Number.isFinite(n) || n <= 0) return undefined
+    return Math.trunc(n)
+  }, z.number().int().positive('Seleccione un rubro')),
   condIva: z.enum(['1', '2', '3']), // 1=21%, 2=10.5%, 3=Exento
   umedida: z.string().min(2).max(6),
   precioLista1: z.coerce.number().positive('Precio debe ser positivo'),
@@ -105,6 +111,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
       role="dialog"
       aria-modal="true"
       aria-labelledby="dialog-articulo-title"
+      data-testid="articulo-form-dialog"
     >
       <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div className="bg-slate-200 dark:bg-slate-700 px-6 py-4 border-b border-slate-300 dark:border-slate-600">
@@ -114,7 +121,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
           <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">{t('form.hint')}</p>
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-4" data-testid="articulo-form">
           {error && (
             <div role="alert" className="p-3 bg-red-100 dark:bg-red-900 text-red-900 dark:text-red-100 rounded border border-red-300 dark:border-red-700">
               {error}
@@ -128,6 +135,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
             <input
               id="articulo-codigo"
               type="number"
+              data-testid="articulo-form-codigo"
               {...register('codigo')}
               aria-required="true"
               aria-describedby={errors.codigo ? 'articulo-codigo-error' : undefined}
@@ -146,6 +154,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
             <input
               id="articulo-descripcion"
               type="text"
+              data-testid="articulo-form-descripcion"
               {...register('descripcion')}
               maxLength={30}
               aria-required="true"
@@ -164,6 +173,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
               </label>
               <select
                 id="articulo-rubroId"
+                data-testid="articulo-form-rubroId"
                 {...register('rubroId')}
                 aria-required="true"
                 aria-describedby={errors.rubroId ? 'articulo-rubroId-error' : undefined}
@@ -225,6 +235,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
                 id="articulo-precioLista1"
                 type="number"
                 step="0.01"
+                data-testid="articulo-form-precioLista1"
                 {...register('precioLista1')}
                 aria-required="true"
                 aria-describedby={errors.precioLista1 ? 'articulo-precioLista1-error' : undefined}
@@ -242,6 +253,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
                 id="articulo-precioLista2"
                 type="number"
                 step="0.01"
+                data-testid="articulo-form-precioLista2"
                 {...register('precioLista2')}
                 aria-required="true"
                 aria-describedby={errors.precioLista2 ? 'articulo-precioLista2-error' : undefined}
@@ -259,6 +271,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
                 id="articulo-costo"
                 type="number"
                 step="0.01"
+                data-testid="articulo-form-costo"
                 {...register('costo')}
                 aria-required="true"
                 aria-describedby={errors.costo ? 'articulo-costo-error' : undefined}
@@ -278,6 +291,7 @@ export default function ArticuloForm({ articulo, rubros, onClose, onGuardado }: 
               <input
                 id="articulo-stock"
                 type="number"
+                data-testid="articulo-form-stock"
                 {...register('stock')}
                 aria-required="true"
                 aria-describedby={errors.stock ? 'articulo-stock-error' : undefined}

--- a/src/pages/articulos/index.tsx
+++ b/src/pages/articulos/index.tsx
@@ -211,6 +211,7 @@ export default function ArticulosPage() {
         ) : (
           <table
             ref={tableRef}
+            data-testid="articulos-table"
             aria-label={t('title')}
             className="w-full border-collapse bg-white dark:bg-slate-800 rounded overflow-hidden border border-slate-200 dark:border-slate-700"
           >


### PR DESCRIPTION
## Resumen

- `ArticuloForm`: `data-testid` en diálogo, formulario y campos clave; `rubroId` con `z.preprocess` para que la opción vacía del `<select>` no se coaccione a `0` y bloquee el submit (mismo patrón que clientes / zona de entrega).
- `articulos/index`: `data-testid="articulos-table"` en la tabla.
- E2E `critical-paths`: flujo crear artículo con `getByTestId`, elección de rubro por índice y aserción de fila; el test de validación de precios usa `articulo-form-precioLista1`.
- CI (`ci.yml`, `frontend-validation.yml`, `qa-validation.yml`): `BIZCODE_SEED_FIXTURE_CATALOG=true` en el paso de `prisma db seed` para el rubro mínimo documentado en paridad de entornos.
- `docs:generate`: SBOM actualizado.

## Verificación local

- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run docs:generate`

Relates to #66
