### PR TITLE
chore(ci): Trivy IaC scan en validación de infraestructura

### DIFF
--- a/.github/workflows/infrastructure-validation.yml
+++ b/.github/workflows/infrastructure-validation.yml
@@ -62,19 +62,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run tfsec (Terraform Security Scan)
-        uses: aquasecurity/tfsec-action@v1.0.3
+      - name: Run Trivy IaC scan (Terraform)
+        uses: aquasecurity/trivy-action@v0.35.0
         continue-on-error: true
         with:
-          working_directory: terraform
+          scan-type: config
+          scan-ref: terraform
           format: json
-          additional_args: -O tfsec.json
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          output: trivy-iac.json
+          hide-progress: true
 
-      - name: Check tfsec Results
+      - name: Check Trivy IaC results
         run: |
-          if [ -f tfsec.json ]; then
-            CRITICAL=$(jq '[.results[] | select(.rule.level=="CRITICAL")] | length' tfsec.json 2>/dev/null || echo 0)
+          if [ -f trivy-iac.json ]; then
+            CRITICAL=$(jq '[.Results[]? | (.Misconfigurations // [])[] | select(.Severity=="CRITICAL")] | length' trivy-iac.json 2>/dev/null || echo 0)
             if [ "$CRITICAL" -gt 0 ]; then
               echo "❌ Found $CRITICAL CRITICAL security issues in Terraform"
               exit 1


### PR DESCRIPTION
Recupera el cambio que estaba en stash (sustituye **tfsec-action** por **aquasecurity/trivy-action** con \scan-type: config\ sobre \	erraform/\). El umbral de fallo sigue siendo solo **CRITICAL** (como el flujo anterior con tfsec).

Verificación local: el job solo corre con cambios en \	erraform/**\, \Dockerfile\ o este workflow; YAML validado en edición.

Made with [Cursor](https://cursor.com)