### PR TITLE
test(server): cerrar #86 — middleware validateBody y errorHandler

### DIFF
--- a/tests/server/middleware-error-correlation.test.ts
+++ b/tests/server/middleware-error-correlation.test.ts
@@ -109,6 +109,22 @@ describe('errorHandler middleware', () => {
     expect(loggerMod.logger.error).toHaveBeenCalled()
   })
 
+  it('exposes error message in development for non-AppError', async () => {
+    process.env.NODE_ENV = 'development'
+
+    const app = express()
+    app.get('/x', (_req, _res, next) => {
+      next(new Error('visible dev message'))
+    })
+    app.use(errorHandler)
+
+    await request(app)
+      .get('/x')
+      .expect(500)
+      .expect({ success: false, error: 'visible dev message' })
+    expect(loggerMod.logger.error).toHaveBeenCalled()
+  })
+
   it('returns early when response headers were already sent', () => {
     process.env.NODE_ENV = 'development'
 

--- a/tests/server/validate-body.test.ts
+++ b/tests/server/validate-body.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for validateBody middleware (#86).
+ */
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { errorHandler } from '../../server/middleware/errorHandler'
+import { validateBody } from '../../server/middleware/validateBody'
+import * as loggerMod from '../../server/logger'
+
+const sampleBodySchema = z.object({
+  name: z.string().min(3, 'name must be at least 3 characters'),
+})
+
+describe('validateBody middleware', () => {
+  beforeEach(() => {
+    vi.spyOn(loggerMod.logger, 'warn').mockImplementation(() => {})
+  })
+
+  it('rewrites req.body with parsed data on success', async () => {
+    const app = express()
+    app.use(express.json())
+    app.post('/ok', validateBody(sampleBodySchema), (req, res) => {
+      const body = req.body as { name: string }
+      res.status(200).json({ name: body.name })
+    })
+    app.use(errorHandler)
+
+    await request(app).post('/ok').send({ name: 'abcd' }).expect(200).expect({ name: 'abcd' })
+  })
+
+  it('forwards ValidationAppError to errorHandler when body fails Zod', async () => {
+    const app = express()
+    app.use(express.json())
+    app.post('/bad', validateBody(sampleBodySchema), (_req, res) => {
+      res.status(200).json({ ok: true })
+    })
+    app.use(errorHandler)
+
+    const res = await request(app).post('/bad').send({ name: 'ab' }).expect(400)
+
+    expect(res.body).toEqual({ success: false, error: 'name must be at least 3 characters' })
+    expect(loggerMod.logger.warn).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Resumen

Cierra la cobertura de pruebas de middleware y auth del servidor (#86): delta sobre PR #106 con prueba unitaria de `validateBody` y caso de `errorHandler` en desarrollo para errores no-AppError.

## Cobertura (matriz)

- PR #106 + `middleware-error-correlation`, `global-rate-limit`, `cors`, `scope-channel`, `correlation-validation-errors`n- `tests/api/authz`, `auth-lockout`n- Nuevo: `tests/server/validate-body.test.ts`; ampliacion `middleware-error-correlation` (dev 500)

## Fuera de alcance

Rate limit por ruta: #87

## Verificacion local

- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run test:integration`
- `npx prisma validate`

Closes #86

Made with [Cursor](https://cursor.com)