### PR TITLE
feat(db): tenant-scoped FK indexes for issue #89

### DIFF
--- a/prisma/migrations/20260511190000_articulo_factura_tenant_fk_indexes/migration.sql
+++ b/prisma/migrations/20260511190000_articulo_factura_tenant_fk_indexes/migration.sql
@@ -1,0 +1,4 @@
+-- Tenant-scoped FK filters for frequent joins and lookups (issue #89).
+
+CREATE INDEX IF NOT EXISTS "Articulo_tenantId_rubroId_idx" ON "Articulo" ("tenantId", "rubroId");
+CREATE INDEX IF NOT EXISTS "Factura_tenantId_clienteId_idx" ON "Factura" ("tenantId", "clienteId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Articulo {
   @@unique([tenantId, codigo])
   @@index([tenantId])
   @@index([tenantId, codigo])
+  @@index([tenantId, rubroId])
 }
 
 model Proveedor {
@@ -179,6 +180,7 @@ model Factura {
   @@unique([tenantId, tipo, prefijo, numero])
   @@index([tenantId])
   @@index([tenantId, fecha])
+  @@index([tenantId, clienteId])
 }
 
 model FacturaItem {

--- a/tests/integration/db-indexes.integration.test.ts
+++ b/tests/integration/db-indexes.integration.test.ts
@@ -1,0 +1,51 @@
+/**
+ * PostgreSQL index presence for tenant-scoped listings and FK filters (issue #89).
+ * Requires DATABASE_URL and applied migrations (`prisma migrate deploy`).
+ */
+import 'dotenv/config'
+import { Prisma, PrismaClient } from '@prisma/client'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const TENANT_SCOPED_INDEXES = [
+  'Cliente_tenantId_codigo_idx',
+  'Articulo_tenantId_codigo_idx',
+  'Articulo_tenantId_rubroId_idx',
+  'Factura_tenantId_fecha_idx',
+  'Factura_tenantId_clienteId_idx',
+] as const
+
+describe('DB — índices tenant-scoped (issue #89)', () => {
+  let prisma: PrismaClient
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL?.trim()) {
+      throw new Error(
+        'DATABASE_URL no está definida. Para pruebas locales: configura .env o exporta DATABASE_URL apuntando a tu PostgreSQL.',
+      )
+    }
+    prisma = new PrismaClient()
+    await prisma.$connect()
+    await prisma.tenant.upsert({
+      where: { id: 1 },
+      create: { id: 1, name: 'Integration tenant', slug: 'integration-tenant-1', active: true },
+      update: { active: true },
+    })
+  })
+
+  afterAll(async () => {
+    await prisma.$disconnect()
+  })
+
+  it('pg_indexes incluye índices tenant-scoped de listados y FK', async () => {
+    const rows = await prisma.$queryRaw<{ indexname: string }[]>`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname IN (${Prisma.join(TENANT_SCOPED_INDEXES)})
+    `
+    const found = new Set(rows.map((row) => row.indexname))
+    for (const indexName of TENANT_SCOPED_INDEXES) {
+      expect(found.has(indexName)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Resumen

Añade indices compuestos tenant-first para joins y filtros frecuentes en Articulo (rubroId) y Factura (clienteId), alineados con las consultas reales del API. Incluye prueba de integracion que verifica presencia de indices en pg_indexes tras migrate deploy.

Closes #89

## Cambios

- prisma/schema.prisma: @@index([tenantId, rubroId]) en Articulo; @@index([tenantId, clienteId]) en Factura.
- Migracion 20260511190000_articulo_factura_tenant_fk_indexes.
- tests/integration/db-indexes.integration.test.ts: aserciones sobre indices tenant+codigo/fecha y nuevos FK.

## Limites / follow-up

- Busqueda parcial contains (rsocial, cuit, descripcion) sin pg_trgm: fuera de alcance; posible follow-up.
- Criterio <100 ms con 100K filas: sin harness en CI.
- Listados con findMany + include: sin N+1 por fila en rutas auditadas.

## Verificacion local

- npm run type-check
- npm run lint
- npm run test (437 tests)
- npm run test:integration (9 tests)
- npx prisma validate

Made with [Cursor](https://cursor.com)