### PR TITLE
refactor(server): domain service layer for issue #90

### DIFF
--- a/server/registerRestDomainRoutes.ts
+++ b/server/registerRestDomainRoutes.ts
@@ -11,6 +11,7 @@ import { registerProveedoresRoutes } from './routes/registerProveedoresRoutes'
 import { registerRubrosRoutes } from './routes/registerRubrosRoutes'
 import type { RestRouteContext } from './routes/restRouteTypes'
 import { registerZonasEntregaRoutes } from './routes/registerZonasEntregaRoutes'
+import { createDomainServices } from './services/createDomainServices'
 
 /**
  * @en Registers core REST handlers (customers, products, invoicing, delivery zones, health).
@@ -35,7 +36,7 @@ export function registerRestDomainRoutes(app: Application, prisma: PrismaClient)
     })
   }
 
-  const ctx: RestRouteContext = { prisma, writeAudit }
+  const ctx: RestRouteContext = { prisma, services: createDomainServices(prisma), writeAudit }
 
   registerClientesRoutes(app, ctx)
   registerArticulosRoutes(app, ctx)

--- a/server/routes/registerArticulosRoutes.ts
+++ b/server/routes/registerArticulosRoutes.ts
@@ -1,8 +1,7 @@
-import { Prisma } from '@prisma/client'
 import type { Application, Request, Response } from 'express'
 import { requirePermission, type AuthenticatedRequest } from '../auth'
 import { validateBody } from '../middleware/validateBody'
-import { articuloBodySchema, safeParseBodySchema } from '../schemas/domain'
+import { articuloBodySchema } from '../schemas/domain'
 import type { ArticuloInput } from '../createApp.types'
 import { parseCsvWithFixedHeaders, CSV_IMPORT_MAX_ROWS } from '../csvImport'
 import { paginatedListJson, parseListPagination } from '../services/listPagination'
@@ -10,7 +9,6 @@ import type { RestRouteContext } from './restRouteTypes'
 import {
   ARTICULO_IMPORT_CSV_HEADERS,
   buildArticuloImportTemplateCsv,
-  csvRowToRawArticulo,
   errorMessage,
   getTenantId,
   singleCsvUpload,
@@ -20,205 +18,107 @@ import {
  * @en Product (articulo) REST routes and CSV import.
  */
 export function registerArticulosRoutes(app: Application, ctx: RestRouteContext): void {
-  const { prisma, writeAudit } = ctx
+  const { services, writeAudit } = ctx
+  const { articulo, import: importService } = services
 
   app.get('/api/articulos', requirePermission('products.read'), async (req: Request, res: Response) => {
     try {
       const tenantId = getTenantId(req)
       const filtro = (req.query.q as string) || ''
       const { take, skip } = parseListPagination(req)
-      const where = {
-        tenantId,
-        OR: [
-          { descripcion: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
-          { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
-        ],
-      }
-      const [total, articulos] = await Promise.all([
-        prisma.articulo.count({ where }),
-        prisma.articulo.findMany({
-          where,
-          include: { rubro: true },
-          orderBy: { codigo: 'asc' },
-          take,
-          skip,
-        }),
-      ])
+      const { total, articulos } = await articulo.list(tenantId, filtro, take, skip)
       res.json(paginatedListJson(articulos, total, take, skip))
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
     }
   })
-  
+
   app.get('/api/articulos/:id', requirePermission('products.read'), async (req: Request, res: Response) => {
     try {
       const tenantId = getTenantId(req)
-      const articulo = await prisma.articulo.findFirst({
-        where: { id: parseInt(String(req.params.id), 10), tenantId },
-        include: { rubro: true },
-      })
-      res.json({ success: true, data: articulo })
+      const data = await articulo.getById(tenantId, parseInt(String(req.params.id), 10))
+      res.json({ success: true, data })
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
     }
   })
-  
+
   app.post(
     '/api/articulos',
     requirePermission('products.manage'),
     validateBody(articuloBodySchema),
     async (req: Request, res: Response) => {
-    try {
-      const tenantId = getTenantId(req)
-      const body = req.body as ArticuloInput
-      const rubro = await prisma.rubro.findFirst({
-        where: { id: body.rubroId, tenantId },
-      })
-      if (!rubro) {
-        res.status(400).json({ success: false, error: 'rubroId is not valid for this tenant' })
-        return
+      try {
+        const tenantId = getTenantId(req)
+        const body = req.body as ArticuloInput
+        const result = await articulo.create(tenantId, body)
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
+          return
+        }
+        await writeAudit(req as AuthenticatedRequest, 'articulo_create', 'articulo', String(result.data.id))
+        res.json({ success: true, data: result.data })
+      } catch (err: unknown) {
+        res.status(500).json({ success: false, error: errorMessage(err) })
       }
-      const articulo = await prisma.articulo.create({
-        data: { ...body, tenantId },
-      })
-      await writeAudit(req as AuthenticatedRequest, 'articulo_create', 'articulo', String(articulo.id))
-      res.json({ success: true, data: articulo })
-    } catch (err: unknown) {
-      res.status(500).json({ success: false, error: errorMessage(err) })
-    }
     },
   )
-  
+
   app.put(
     '/api/articulos/:id',
     requirePermission('products.manage'),
     validateBody(articuloBodySchema),
     async (req: Request, res: Response) => {
-    try {
-      const tenantId = getTenantId(req)
-      const body = req.body as ArticuloInput
-      const rubro = await prisma.rubro.findFirst({
-        where: { id: body.rubroId, tenantId },
-      })
-      if (!rubro) {
-        res.status(400).json({ success: false, error: 'rubroId is not valid for this tenant' })
-        return
+      try {
+        const tenantId = getTenantId(req)
+        const body = req.body as ArticuloInput
+        const result = await articulo.update(tenantId, parseInt(String(req.params.id), 10), body)
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
+          return
+        }
+        await writeAudit(req as AuthenticatedRequest, 'articulo_update', 'articulo', String(result.data.id))
+        res.json({ success: true, data: result.data })
+      } catch (err: unknown) {
+        res.status(500).json({ success: false, error: errorMessage(err) })
       }
-      const id = parseInt(String(req.params.id), 10)
-      const existing = await prisma.articulo.findFirst({ where: { id, tenantId } })
-      if (!existing) {
-        res.status(404).json({ success: false, error: 'Articulo not found' })
-        return
-      }
-      const articulo = await prisma.articulo.update({
-        where: { id },
-        data: body,
-      })
-      await writeAudit(req as AuthenticatedRequest, 'articulo_update', 'articulo', String(articulo.id))
-      res.json({ success: true, data: articulo })
-    } catch (err: unknown) {
-      res.status(500).json({ success: false, error: errorMessage(err) })
-    }
     },
   )
-  
+
   app.get('/api/articulos/import/template', requirePermission('products.manage'), (_req: Request, res: Response) => {
     const body = buildArticuloImportTemplateCsv()
     res.setHeader('Content-Type', 'text/csv; charset=utf-8')
     res.setHeader('Content-Disposition', 'attachment; filename="articulos_import_template.csv"')
     res.send(body)
   })
-  
+
   app.post('/api/articulos/import', requirePermission('products.manage'), singleCsvUpload, (req: Request, res: Response) => {
     void (async () => {
-    const file = (req as Request & { file?: { buffer: Buffer } }).file
-    if (!file?.buffer) {
-      res.status(400).json({ success: false, error: 'Expected multipart field "file" with a .csv file' })
-      return
-    }
-    try {
-          const tenantId = getTenantId(req)
-          const parsedCsv = parseCsvWithFixedHeaders(file.buffer, ARTICULO_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
-          if (!parsedCsv.ok) {
-            res.status(400).json({ success: false, error: parsedCsv.error })
-            return
-          }
-          const rubrosDb = await prisma.rubro.findMany({
-            where: { tenantId },
-            select: { id: true, codigo: true },
-          })
-          const rubroByCodigo = new Map(rubrosDb.map((r) => [r.codigo, r.id]))
-          const errors: { row: number; message: string }[] = []
-          const seenCodigos = new Map<number, number>()
-          const validatedRows: { row: number; input: ArticuloInput }[] = []
-          for (const [i, row] of parsedCsv.records.entries()) {
-            const rowNum = i + 2
-            const raw = csvRowToRawArticulo(row)
-            const rubroCodigo = raw.rubroCodigo
-            if (typeof rubroCodigo !== 'number' || !Number.isInteger(rubroCodigo)) {
-              errors.push({ row: rowNum, message: 'rubroCodigo must be a valid integer' })
-              continue
-            }
-            const rubroId = rubroByCodigo.get(rubroCodigo)
-            if (rubroId === undefined) {
-              errors.push({ row: rowNum, message: `Unknown rubroCodigo ${rubroCodigo}` })
-              continue
-            }
-            const { rubroCodigo: _rc, ...rest } = raw
-            const forValidate = { ...rest, rubroId }
-            const parsed = safeParseBodySchema(articuloBodySchema, forValidate)
-            if (!parsed.ok) {
-              errors.push({ row: rowNum, message: parsed.error })
-              continue
-            }
-            const codigo = parsed.value.codigo
-            const firstRow = seenCodigos.get(codigo)
-            if (firstRow !== undefined) {
-              errors.push({
-                row: rowNum,
-                message: `Duplicate codigo ${codigo} (first occurrence on row ${firstRow})`,
-              })
-              continue
-            }
-            seenCodigos.set(codigo, rowNum)
-            validatedRows.push({ row: rowNum, input: parsed.value })
-          }
-          const codigos = validatedRows.map((r) => r.input.codigo)
-          const existing =
-            codigos.length === 0
-              ? []
-              : await prisma.articulo.findMany({
-                  where: { tenantId, codigo: { in: codigos } },
-                  select: { codigo: true },
-                })
-          const existingSet = new Set(existing.map((e) => e.codigo))
-          const toInsert: ArticuloInput[] = []
-          for (const vr of validatedRows) {
-            if (existingSet.has(vr.input.codigo)) {
-              errors.push({ row: vr.row, message: `codigo ${vr.input.codigo} already exists` })
-              continue
-            }
-            toInsert.push(vr.input)
-          }
-          let created = 0
-          await prisma.$transaction(async (tx) => {
-            for (const data of toInsert) {
-              await tx.articulo.create({ data: { ...data, tenantId } })
-              created += 1
-            }
-          })
-          const authReq = req as AuthenticatedRequest
-          await writeAudit(authReq, 'articulo_import', 'articulo', undefined, {
-            createdCount: created,
-            errorCount: errors.length,
-          })
-          res.json({
-            success: true,
-            data: { created, skipped: errors.length, errors },
-          })
-    } catch (err: unknown) {
-      res.status(500).json({ success: false, error: errorMessage(err) })
-    }
+      const file = (req as Request & { file?: { buffer: Buffer } }).file
+      if (!file?.buffer) {
+        res.status(400).json({ success: false, error: 'Expected multipart field "file" with a .csv file' })
+        return
+      }
+      try {
+        const tenantId = getTenantId(req)
+        const parsedCsv = parseCsvWithFixedHeaders(file.buffer, ARTICULO_IMPORT_CSV_HEADERS, CSV_IMPORT_MAX_ROWS)
+        if (!parsedCsv.ok) {
+          res.status(400).json({ success: false, error: parsedCsv.error })
+          return
+        }
+        const { created, errors } = await importService.importArticulos(tenantId, parsedCsv.records)
+        const authReq = req as AuthenticatedRequest
+        await writeAudit(authReq, 'articulo_import', 'articulo', undefined, {
+          createdCount: created,
+          errorCount: errors.length,
+        })
+        res.json({
+          success: true,
+          data: { created, skipped: errors.length, errors },
+        })
+      } catch (err: unknown) {
+        res.status(500).json({ success: false, error: errorMessage(err) })
+      }
     })()
   })
 }

--- a/server/routes/registerClientesRoutes.ts
+++ b/server/routes/registerClientesRoutes.ts
@@ -1,8 +1,7 @@
-import { Prisma } from '@prisma/client'
 import type { Application, Request, Response } from 'express'
 import { requirePermission, type AuthenticatedRequest } from '../auth'
 import { validateBody } from '../middleware/validateBody'
-import { clienteBodySchema, safeParseBodySchema } from '../schemas/domain'
+import { clienteBodySchema } from '../schemas/domain'
 import type { ClienteInput } from '../createApp.types'
 import { parseCsvWithFixedHeaders, CSV_IMPORT_MAX_ROWS } from '../csvImport'
 import { paginatedListJson, parseListPagination } from '../services/listPagination'
@@ -10,7 +9,6 @@ import type { RestRouteContext } from './restRouteTypes'
 import {
   buildClienteImportTemplateCsv,
   CLIENTE_IMPORT_CSV_HEADERS,
-  csvRowToRawCliente,
   errorMessage,
   getTenantId,
   singleCsvUpload,
@@ -20,30 +18,15 @@ import {
  * @en Customer REST routes (`/api/clientes`, CSV import).
  */
 export function registerClientesRoutes(app: Application, ctx: RestRouteContext): void {
-  const { prisma, writeAudit } = ctx
+  const { services, writeAudit } = ctx
+  const { cliente, import: importService } = services
 
   app.get('/api/clientes', requirePermission('customers.read'), async (req: Request, res: Response) => {
     try {
       const tenantId = getTenantId(req)
       const filtro = (req.query.q as string) || ''
       const { take, skip } = parseListPagination(req)
-      const where = {
-        tenantId,
-        OR: [
-          { rsocial: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
-          { cuit: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
-          { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
-        ],
-      }
-      const [total, clientes] = await Promise.all([
-        prisma.cliente.count({ where }),
-        prisma.cliente.findMany({
-          where,
-          orderBy: { codigo: 'asc' },
-          take,
-          skip,
-        }),
-      ])
+      const { total, clientes } = await cliente.list(tenantId, filtro, take, skip)
       res.json(paginatedListJson(clientes, total, take, skip))
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
@@ -71,53 +54,7 @@ export function registerClientesRoutes(app: Application, ctx: RestRouteContext):
           res.status(400).json({ success: false, error: parsedCsv.error })
           return
         }
-        const errors: { row: number; message: string }[] = []
-        const seenCodigos = new Map<number, number>()
-        const validatedRows: { row: number; input: ClienteInput }[] = []
-        for (const [i, row] of parsedCsv.records.entries()) {
-          const rowNum = i + 2
-          const raw = csvRowToRawCliente(row)
-          const parsed = safeParseBodySchema(clienteBodySchema, raw)
-          if (!parsed.ok) {
-            errors.push({ row: rowNum, message: parsed.error })
-            continue
-          }
-          const codigo = parsed.value.codigo
-          const firstRow = seenCodigos.get(codigo)
-          if (firstRow !== undefined) {
-            errors.push({
-              row: rowNum,
-              message: `Duplicate codigo ${codigo} (first occurrence on row ${firstRow})`,
-            })
-            continue
-          }
-          seenCodigos.set(codigo, rowNum)
-          validatedRows.push({ row: rowNum, input: parsed.value })
-        }
-        const codigos = validatedRows.map((r) => r.input.codigo)
-        const existing =
-          codigos.length === 0
-            ? []
-            : await prisma.cliente.findMany({
-                where: { tenantId, codigo: { in: codigos } },
-                select: { codigo: true },
-              })
-        const existingSet = new Set(existing.map((e) => e.codigo))
-        const toInsert: ClienteInput[] = []
-        for (const vr of validatedRows) {
-          if (existingSet.has(vr.input.codigo)) {
-            errors.push({ row: vr.row, message: `codigo ${vr.input.codigo} already exists` })
-            continue
-          }
-          toInsert.push(vr.input)
-        }
-        let created = 0
-        await prisma.$transaction(async (tx) => {
-          for (const data of toInsert) {
-            await tx.cliente.create({ data: { ...data, tenantId } })
-            created += 1
-          }
-        })
+        const { created, errors } = await importService.importClientes(tenantId, parsedCsv.records)
         const authReq = req as AuthenticatedRequest
         await writeAudit(authReq, 'cliente_import', 'cliente', undefined, {
           createdCount: created,
@@ -136,10 +73,8 @@ export function registerClientesRoutes(app: Application, ctx: RestRouteContext):
   app.get('/api/clientes/:id', requirePermission('customers.read'), async (req: Request, res: Response) => {
     try {
       const tenantId = getTenantId(req)
-      const cliente = await prisma.cliente.findFirst({
-        where: { id: parseInt(String(req.params.id), 10), tenantId },
-      })
-      res.json({ success: true, data: cliente })
+      const data = await cliente.getById(tenantId, parseInt(String(req.params.id), 10))
+      res.json({ success: true, data })
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
     }
@@ -153,20 +88,13 @@ export function registerClientesRoutes(app: Application, ctx: RestRouteContext):
       try {
         const tenantId = getTenantId(req)
         const body = req.body as ClienteInput
-        if (body.deliveryZoneId != null) {
-          const zone = await prisma.deliveryZone.findFirst({
-            where: { id: body.deliveryZoneId, tenantId },
-          })
-          if (!zone) {
-            res.status(400).json({ success: false, error: 'deliveryZoneId does not belong to this tenant' })
-            return
-          }
+        const result = await cliente.create(tenantId, body)
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
+          return
         }
-        const cliente = await prisma.cliente.create({
-          data: { ...body, tenantId },
-        })
-        await writeAudit(req as AuthenticatedRequest, 'cliente_create', 'cliente', String(cliente.id))
-        res.json({ success: true, data: cliente })
+        await writeAudit(req as AuthenticatedRequest, 'cliente_create', 'cliente', String(result.data.id))
+        res.json({ success: true, data: result.data })
       } catch (err: unknown) {
         res.status(500).json({ success: false, error: errorMessage(err) })
       }
@@ -184,35 +112,18 @@ export function registerClientesRoutes(app: Application, ctx: RestRouteContext):
         const authReq = req as AuthenticatedRequest
         const role = authReq.auth?.claims.role
         const canManageFinancials = role === 'owner' || role === 'manager'
-
-        const { creditLimit, creditDays, suspended, ...baseBody } = parsedBody
-        const data = canManageFinancials
-          ? { ...baseBody, creditLimit, creditDays, suspended }
-          : baseBody
-
-        if (data.deliveryZoneId != null) {
-          const zone = await prisma.deliveryZone.findFirst({
-            where: { id: data.deliveryZoneId, tenantId },
-          })
-          if (!zone) {
-            res.status(400).json({ success: false, error: 'deliveryZoneId does not belong to this tenant' })
-            return
-          }
-        }
-
-        const id = parseInt(String(req.params.id), 10)
-        const existingCliente = await prisma.cliente.findFirst({ where: { id, tenantId } })
-        if (!existingCliente) {
-          res.status(404).json({ success: false, error: 'Cliente not found' })
+        const result = await cliente.update(
+          tenantId,
+          parseInt(String(req.params.id), 10),
+          parsedBody,
+          canManageFinancials,
+        )
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
           return
         }
-
-        const cliente = await prisma.cliente.update({
-          where: { id },
-          data,
-        })
-        await writeAudit(authReq, 'cliente_update', 'cliente', String(cliente.id))
-        res.json({ success: true, data: cliente })
+        await writeAudit(authReq, 'cliente_update', 'cliente', String(result.data.id))
+        res.json({ success: true, data: result.data })
       } catch (err: unknown) {
         res.status(500).json({ success: false, error: errorMessage(err) })
       }

--- a/server/routes/registerFacturasRoutes.ts
+++ b/server/routes/registerFacturasRoutes.ts
@@ -6,160 +6,82 @@ import type { FacturaInput } from '../createApp.types'
 import { paginatedListJson, parseListPagination } from '../services/listPagination'
 import { dispatchNotification } from '../channels'
 import type { RestRouteContext } from './restRouteTypes'
-import { errorMessage, facturaFechaToPrismaDate, getTenantId } from './restDomainShared'
+import { errorMessage, getTenantId } from './restDomainShared'
 
 /**
  * @en Invoice create/list and void routes.
  */
 export function registerFacturasRoutes(app: Application, ctx: RestRouteContext): void {
-  const { prisma, writeAudit } = ctx
+  const { prisma, services, writeAudit } = ctx
+  const { factura } = services
 
-  
   app.get('/api/facturas', requirePermission('reports.operational.read'), async (req: Request, res: Response) => {
     try {
       const tenantId = getTenantId(req)
       const { take, skip } = parseListPagination(req)
-      const where = { tenantId }
-      const [total, facturas] = await Promise.all([
-        prisma.factura.count({ where }),
-        prisma.factura.findMany({
-          where,
-          include: { cliente: true, items: true },
-          orderBy: { fecha: 'desc' },
-          take,
-          skip,
-        }),
-      ])
+      const { total, facturas } = await factura.list(tenantId, take, skip)
       res.json(paginatedListJson(facturas, total, take, skip))
     } catch (err: unknown) {
       res.status(500).json({ success: false, error: errorMessage(err) })
     }
   })
-  
+
   app.post(
     '/api/facturas',
     requirePermission('sales.create'),
     validateBody(facturaBodySchema),
     async (req: Request, res: Response) => {
-    try {
-      const tenantId = getTenantId(req)
-      const parsedValue = req.body as FacturaInput
-      const { items, fecha, ...factura } = parsedValue
-      const clienteId = factura.clienteId
-  
-      const articuloIds = [...new Set(items.map((it) => it.articuloId))]
-      const articulosOk = await prisma.articulo.findMany({
-        where: { tenantId, id: { in: articuloIds } },
-        select: { id: true },
-      })
-      if (articulosOk.length !== articuloIds.length) {
-        res.status(400).json({ success: false, error: 'One or more articuloId values are not valid for this tenant' })
-        return
+      try {
+        const tenantId = getTenantId(req)
+        const parsedValue = req.body as FacturaInput
+        const result = await factura.create(tenantId, parsedValue)
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
+          return
+        }
+
+        const { factura: createdFactura, updatedCliente } = result.data
+        if (
+          updatedCliente.creditLimit !== null &&
+          Number(updatedCliente.balance) > Number(updatedCliente.creditLimit)
+        ) {
+          const authReq = req as AuthenticatedRequest
+          dispatchNotification(prisma, authReq.auth!.claims.tenantId, 'credit_limit_exceeded', {
+            clienteId: updatedCliente.id,
+            rsocial: updatedCliente.rsocial,
+            amount: String(updatedCliente.balance),
+            limit: String(updatedCliente.creditLimit),
+          }).catch(() => { /* notification failure must not block the sale */ })
+        }
+
+        await writeAudit(req as AuthenticatedRequest, 'factura_create', 'factura', String(createdFactura.id))
+        res.json({ success: true, data: createdFactura })
+      } catch (err: unknown) {
+        res.status(500).json({ success: false, error: errorMessage(err) })
       }
-  
-      // Check suspension before creating the factura
-      const clienteCheck = await prisma.cliente.findFirst({
-        where: { id: clienteId, tenantId },
-        select: { suspended: true },
-      })
-      if (!clienteCheck) {
-        res.status(400).json({ success: false, error: 'clienteId is not valid for this tenant' })
-        return
-      }
-      if (clienteCheck.suspended) {
-        res.status(422).json({ success: false, error: 'CLIENT_SUSPENDED' })
-        return
-      }
-  
-      // Create factura and update customer balance atomically
-      const [result, updatedCliente] = await prisma.$transaction(async (tx) => {
-        const newFactura = await tx.factura.create({
-          data: {
-            ...factura,
-            fecha: facturaFechaToPrismaDate(fecha),
-            tenantId,
-            items: { create: items },
-          } as Parameters<typeof prisma.factura.create>[0]['data'],
-          include: { items: true },
-        })
-  
-        const updated = await tx.cliente.update({
-          where: { id: clienteId },
-          data: { balance: { increment: newFactura.total } },
-          select: { id: true, rsocial: true, balance: true, creditLimit: true },
-        })
-  
-        return [newFactura, updated] as const
-      })
-  
-      // Dispatch to all configured channels if balance exceeds credit limit (non-blocking)
-      if (
-        updatedCliente.creditLimit !== null &&
-        Number(updatedCliente.balance) > Number(updatedCliente.creditLimit)
-      ) {
-        const authReq = req as AuthenticatedRequest
-        dispatchNotification(prisma, authReq.auth!.claims.tenantId, 'credit_limit_exceeded', {
-          clienteId: updatedCliente.id,
-          rsocial: updatedCliente.rsocial,
-          amount: String(updatedCliente.balance),
-          limit: String(updatedCliente.creditLimit),
-        }).catch(() => { /* notification failure must not block the sale */ })
-      }
-  
-      await writeAudit(req as AuthenticatedRequest, 'factura_create', 'factura', String(result.id))
-      res.json({ success: true, data: result })
-    } catch (err: unknown) {
-      res.status(500).json({ success: false, error: errorMessage(err) })
-    }
     },
   )
-  
-  // ============ ANULACIÓN DE FACTURAS ============
-  
+
   app.put(
     '/api/facturas/:id/void',
     requirePermission('sales.cancel'),
     validateBody(facturaVoidBodySchema),
     async (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const tenantId = getTenantId(req)
-      const id = parseInt(String(req.params.id), 10)
-      const { motivo } = req.body as { motivo: string }
-  
-      const factura = await prisma.factura.findFirst({
-        where: { id, tenantId },
-        select: { id: true, estado: true, total: true, clienteId: true },
-      })
-  
-      if (!factura) {
-        res.status(404).json({ success: false, error: 'Factura not found' })
-        return
+      try {
+        const authReq = req as AuthenticatedRequest
+        const tenantId = getTenantId(req)
+        const id = parseInt(String(req.params.id), 10)
+        const { motivo } = req.body as { motivo: string }
+        const result = await factura.void(tenantId, id)
+        if (!result.ok) {
+          res.status(result.status).json({ success: false, error: result.error })
+          return
+        }
+        await writeAudit(authReq, 'factura_void', 'factura', String(id), { motivo })
+        res.json({ success: true, data: result.data })
+      } catch (err: unknown) {
+        res.status(500).json({ success: false, error: errorMessage(err) })
       }
-  
-      if (factura.estado === 'N') {
-        res.status(409).json({ success: false, error: 'Factura already voided' })
-        return
-      }
-  
-      // Void atomically: set estado='N', reverse customer balance
-      const updated = await prisma.$transaction(async (tx) => {
-        const voided = await tx.factura.update({
-          where: { id },
-          data: { estado: 'N' },
-        })
-        await tx.cliente.update({
-          where: { id: factura.clienteId },
-          data: { balance: { decrement: factura.total } },
-        })
-        return voided
-      })
-  
-      await writeAudit(authReq, 'factura_void', 'factura', String(id), { motivo })
-      res.json({ success: true, data: updated })
-    } catch (err: unknown) {
-      res.status(500).json({ success: false, error: errorMessage(err) })
-    }
     },
   )
 }

--- a/server/routes/restRouteTypes.ts
+++ b/server/routes/restRouteTypes.ts
@@ -1,8 +1,10 @@
 import type { PrismaClient, Prisma } from '@prisma/client'
 import type { AuthenticatedRequest } from '../auth'
+import type { DomainServices } from '../services/createDomainServices'
 
 export type RestRouteContext = {
   prisma: PrismaClient
+  services: DomainServices
   writeAudit: (
     req: AuthenticatedRequest,
     action: string,

--- a/server/services/ArticuloService.ts
+++ b/server/services/ArticuloService.ts
@@ -1,0 +1,84 @@
+import { Prisma, type Articulo, type PrismaClient } from '@prisma/client'
+import type { ArticuloInput } from '../createApp.types'
+import type { ServiceResult } from './serviceResults'
+
+type ArticuloWithRubro = Prisma.ArticuloGetPayload<{ include: { rubro: true } }>
+
+export type ArticuloListResult = {
+  total: number
+  articulos: ArticuloWithRubro[]
+}
+
+/**
+ * @en Product (articulo) domain operations.
+ * @es Operaciones de dominio de artículos.
+ * @pt-BR Operações de domínio de artigos.
+ */
+export class ArticuloService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async list(tenantId: number, filtro: string, take: number, skip: number): Promise<ArticuloListResult> {
+    const where = {
+      tenantId,
+      OR: [
+        { descripcion: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
+        { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
+      ],
+    }
+    const [total, articulos] = await Promise.all([
+      this.prisma.articulo.count({ where }),
+      this.prisma.articulo.findMany({
+        where,
+        include: { rubro: true },
+        orderBy: { codigo: 'asc' },
+        take,
+        skip,
+      }),
+    ])
+    return { total, articulos }
+  }
+
+  async getById(tenantId: number, id: number): Promise<ArticuloWithRubro | null> {
+    return this.prisma.articulo.findFirst({
+      where: { id, tenantId },
+      include: { rubro: true },
+    })
+  }
+
+  async create(tenantId: number, body: ArticuloInput): Promise<ServiceResult<Articulo>> {
+    const rubroCheck = await this.validateRubro(tenantId, body.rubroId)
+    if (!rubroCheck.ok) {
+      return rubroCheck
+    }
+    const articulo = await this.prisma.articulo.create({
+      data: { ...body, tenantId },
+    })
+    return { ok: true, data: articulo }
+  }
+
+  async update(tenantId: number, id: number, body: ArticuloInput): Promise<ServiceResult<Articulo>> {
+    const rubroCheck = await this.validateRubro(tenantId, body.rubroId)
+    if (!rubroCheck.ok) {
+      return rubroCheck
+    }
+    const existing = await this.prisma.articulo.findFirst({ where: { id, tenantId } })
+    if (!existing) {
+      return { ok: false, status: 404, error: 'Articulo not found' }
+    }
+    const articulo = await this.prisma.articulo.update({
+      where: { id },
+      data: body,
+    })
+    return { ok: true, data: articulo }
+  }
+
+  private async validateRubro(tenantId: number, rubroId: number): Promise<ServiceResult<null>> {
+    const rubro = await this.prisma.rubro.findFirst({
+      where: { id: rubroId, tenantId },
+    })
+    if (!rubro) {
+      return { ok: false, status: 400, error: 'rubroId is not valid for this tenant' }
+    }
+    return { ok: true, data: null }
+  }
+}

--- a/server/services/ClienteService.ts
+++ b/server/services/ClienteService.ts
@@ -1,0 +1,97 @@
+import { Prisma, type Cliente, type PrismaClient } from '@prisma/client'
+import type { ClienteInput } from '../createApp.types'
+import type { ServiceResult } from './serviceResults'
+
+export type ClienteListResult = {
+  total: number
+  clientes: Cliente[]
+}
+
+/**
+ * @en Customer domain operations (list, read, create, update).
+ * @es Operaciones de dominio de clientes (listado, lectura, alta, actualización).
+ * @pt-BR Operações de domínio de clientes (listagem, leitura, criação, atualização).
+ */
+export class ClienteService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async list(tenantId: number, filtro: string, take: number, skip: number): Promise<ClienteListResult> {
+    const where = {
+      tenantId,
+      OR: [
+        { rsocial: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
+        { cuit: { contains: filtro, mode: Prisma.QueryMode.insensitive } },
+        { codigo: { equals: filtro ? parseInt(filtro, 10) : undefined } },
+      ],
+    }
+    const [total, clientes] = await Promise.all([
+      this.prisma.cliente.count({ where }),
+      this.prisma.cliente.findMany({
+        where,
+        orderBy: { codigo: 'asc' },
+        take,
+        skip,
+      }),
+    ])
+    return { total, clientes }
+  }
+
+  async getById(tenantId: number, id: number): Promise<Cliente | null> {
+    return this.prisma.cliente.findFirst({
+      where: { id, tenantId },
+    })
+  }
+
+  async create(tenantId: number, body: ClienteInput): Promise<ServiceResult<Cliente>> {
+    const zoneCheck = await this.validateDeliveryZone(tenantId, body.deliveryZoneId)
+    if (!zoneCheck.ok) {
+      return zoneCheck
+    }
+    const cliente = await this.prisma.cliente.create({
+      data: { ...body, tenantId },
+    })
+    return { ok: true, data: cliente }
+  }
+
+  async update(
+    tenantId: number,
+    id: number,
+    body: ClienteInput,
+    canManageFinancials: boolean,
+  ): Promise<ServiceResult<Cliente>> {
+    const { creditLimit, creditDays, suspended, ...baseBody } = body
+    const data = canManageFinancials ? { ...baseBody, creditLimit, creditDays, suspended } : baseBody
+
+    const zoneCheck = await this.validateDeliveryZone(tenantId, data.deliveryZoneId)
+    if (!zoneCheck.ok) {
+      return zoneCheck
+    }
+
+    const existingCliente = await this.prisma.cliente.findFirst({ where: { id, tenantId } })
+    if (!existingCliente) {
+      return { ok: false, status: 404, error: 'Cliente not found' }
+    }
+
+    const cliente = await this.prisma.cliente.update({
+      where: { id },
+      data,
+    })
+    return { ok: true, data: cliente }
+  }
+
+  private async validateDeliveryZone(
+    tenantId: number,
+    deliveryZoneId: number | null | undefined,
+  ): Promise<ServiceResult<null>> {
+    if (deliveryZoneId == null) {
+      return { ok: true, data: null }
+    }
+    const zone = await this.prisma.deliveryZone.findFirst({
+      where: { id: deliveryZoneId, tenantId },
+    })
+    if (!zone) {
+      return { ok: false, status: 400, error: 'deliveryZoneId does not belong to this tenant' }
+    }
+    return { ok: true, data: null }
+  }
+}

--- a/server/services/FacturaService.ts
+++ b/server/services/FacturaService.ts
@@ -1,0 +1,120 @@
+import type { Cliente, Factura, Prisma, PrismaClient } from '@prisma/client'
+import type { FacturaInput } from '../createApp.types'
+import { facturaFechaToPrismaDate } from '../routes/restDomainShared'
+import type { ServiceResult } from './serviceResults'
+
+type FacturaWithRelations = Prisma.FacturaGetPayload<{ include: { cliente: true; items: true } }>
+
+export type FacturaListResult = {
+  total: number
+  facturas: FacturaWithRelations[]
+}
+
+export type FacturaCreateResult = {
+  factura: FacturaWithRelations
+  updatedCliente: Pick<Cliente, 'id' | 'rsocial' | 'balance' | 'creditLimit'>
+}
+
+/**
+ * @en Invoice domain operations (list, create, void).
+ * @es Operaciones de dominio de facturas (listado, alta, anulación).
+ * @pt-BR Operações de domínio de faturas (listagem, criação, anulação).
+ */
+export class FacturaService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async list(tenantId: number, take: number, skip: number): Promise<FacturaListResult> {
+    const where = { tenantId }
+    const [total, facturas] = await Promise.all([
+      this.prisma.factura.count({ where }),
+      this.prisma.factura.findMany({
+        where,
+        include: { cliente: true, items: true },
+        orderBy: { fecha: 'desc' },
+        take,
+        skip,
+      }),
+    ])
+    return { total, facturas }
+  }
+
+  async create(tenantId: number, input: FacturaInput): Promise<ServiceResult<FacturaCreateResult>> {
+    const { items, fecha, ...factura } = input
+    const clienteId = factura.clienteId
+
+    const articuloIds = [...new Set(items.map((it) => it.articuloId))]
+    const articulosOk = await this.prisma.articulo.findMany({
+      where: { tenantId, id: { in: articuloIds } },
+      select: { id: true },
+    })
+    if (articulosOk.length !== articuloIds.length) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'One or more articuloId values are not valid for this tenant',
+      }
+    }
+
+    const clienteCheck = await this.prisma.cliente.findFirst({
+      where: { id: clienteId, tenantId },
+      select: { suspended: true },
+    })
+    if (!clienteCheck) {
+      return { ok: false, status: 400, error: 'clienteId is not valid for this tenant' }
+    }
+    if (clienteCheck.suspended) {
+      return { ok: false, status: 422, error: 'CLIENT_SUSPENDED' }
+    }
+
+    const [newFactura, updatedCliente] = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.factura.create({
+        data: {
+          ...factura,
+          fecha: facturaFechaToPrismaDate(fecha),
+          tenantId,
+          items: { create: items },
+        } as Parameters<typeof this.prisma.factura.create>[0]['data'],
+        include: { items: true, cliente: true },
+      })
+
+      const updated = await tx.cliente.update({
+        where: { id: clienteId },
+        data: { balance: { increment: created.total } },
+        select: { id: true, rsocial: true, balance: true, creditLimit: true },
+      })
+
+      return [created, updated] as const
+    })
+
+    return { ok: true, data: { factura: newFactura, updatedCliente } }
+  }
+
+  async void(tenantId: number, id: number): Promise<ServiceResult<Factura>> {
+    const factura = await this.prisma.factura.findFirst({
+      where: { id, tenantId },
+      select: { id: true, estado: true, total: true, clienteId: true },
+    })
+
+    if (!factura) {
+      return { ok: false, status: 404, error: 'Factura not found' }
+    }
+
+    if (factura.estado === 'N') {
+      return { ok: false, status: 409, error: 'Factura already voided' }
+    }
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const voided = await tx.factura.update({
+        where: { id },
+        data: { estado: 'N' },
+      })
+      await tx.cliente.update({
+        where: { id: factura.clienteId },
+        data: { balance: { decrement: factura.total } },
+      })
+      return voided
+    })
+
+    return { ok: true, data: updated }
+  }
+}

--- a/server/services/ImportService.ts
+++ b/server/services/ImportService.ts
@@ -1,0 +1,162 @@
+import type { PrismaClient } from '@prisma/client'
+import type { ArticuloInput, ClienteInput } from '../createApp.types'
+import { articuloBodySchema, clienteBodySchema, safeParseBodySchema } from '../schemas/domain'
+import { csvRowToRawArticulo, csvRowToRawCliente } from '../routes/restDomainShared'
+import type { ImportPersistResult, ImportRowError } from './serviceResults'
+
+type ValidatedImportRow<T> = {
+  row: number
+  input: T
+}
+
+/**
+ * @en Bulk CSV import persistence for tenant-scoped catalog entities.
+ * @es Persistencia de importaciones CSV masivas para entidades de catálogo por tenant.
+ * @pt-BR Persistência de importações CSV em massa para entidades de catálogo por tenant.
+ */
+export class ImportService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async importClientes(tenantId: number, records: Record<string, string>[]): Promise<ImportPersistResult> {
+    const errors: ImportRowError[] = []
+    const seenCodigos = new Map<number, number>()
+    const validatedRows: ValidatedImportRow<ClienteInput>[] = []
+
+    for (const [i, row] of records.entries()) {
+      const rowNum = i + 2
+      const raw = csvRowToRawCliente(row)
+      const parsed = safeParseBodySchema(clienteBodySchema, raw)
+      if (!parsed.ok) {
+        errors.push({ row: rowNum, message: parsed.error })
+        continue
+      }
+      const codigo = parsed.value.codigo
+      const firstRow = seenCodigos.get(codigo)
+      if (firstRow !== undefined) {
+        errors.push({
+          row: rowNum,
+          message: `Duplicate codigo ${codigo} (first occurrence on row ${firstRow})`,
+        })
+        continue
+      }
+      seenCodigos.set(codigo, rowNum)
+      validatedRows.push({ row: rowNum, input: parsed.value })
+    }
+
+    return this.persistClientesByCodigo(tenantId, validatedRows, errors)
+  }
+
+  async importArticulos(tenantId: number, records: Record<string, string>[]): Promise<ImportPersistResult> {
+    const rubrosDb = await this.prisma.rubro.findMany({
+      where: { tenantId },
+      select: { id: true, codigo: true },
+    })
+    const rubroByCodigo = new Map(rubrosDb.map((r) => [r.codigo, r.id]))
+    const errors: ImportRowError[] = []
+    const seenCodigos = new Map<number, number>()
+    const validatedRows: ValidatedImportRow<ArticuloInput>[] = []
+
+    for (const [i, row] of records.entries()) {
+      const rowNum = i + 2
+      const raw = csvRowToRawArticulo(row)
+      const rubroCodigo = raw.rubroCodigo
+      if (typeof rubroCodigo !== 'number' || !Number.isInteger(rubroCodigo)) {
+        errors.push({ row: rowNum, message: 'rubroCodigo must be a valid integer' })
+        continue
+      }
+      const rubroId = rubroByCodigo.get(rubroCodigo)
+      if (rubroId === undefined) {
+        errors.push({ row: rowNum, message: `Unknown rubroCodigo ${rubroCodigo}` })
+        continue
+      }
+      const { rubroCodigo: _rc, ...rest } = raw
+      const forValidate = { ...rest, rubroId }
+      const parsed = safeParseBodySchema(articuloBodySchema, forValidate)
+      if (!parsed.ok) {
+        errors.push({ row: rowNum, message: parsed.error })
+        continue
+      }
+      const codigo = parsed.value.codigo
+      const firstRow = seenCodigos.get(codigo)
+      if (firstRow !== undefined) {
+        errors.push({
+          row: rowNum,
+          message: `Duplicate codigo ${codigo} (first occurrence on row ${firstRow})`,
+        })
+        continue
+      }
+      seenCodigos.set(codigo, rowNum)
+      validatedRows.push({ row: rowNum, input: parsed.value })
+    }
+
+    return this.persistArticulosByCodigo(tenantId, validatedRows, errors)
+  }
+
+  private async persistClientesByCodigo(
+    tenantId: number,
+    validatedRows: ValidatedImportRow<ClienteInput>[],
+    errors: ImportRowError[],
+  ): Promise<ImportPersistResult> {
+    const codigos = validatedRows.map((r) => r.input.codigo)
+    const existing =
+      codigos.length === 0
+        ? []
+        : await this.prisma.cliente.findMany({
+            where: { tenantId, codigo: { in: codigos } },
+            select: { codigo: true },
+          })
+    const existingSet = new Set(existing.map((e) => e.codigo))
+    const toInsert: ClienteInput[] = []
+    for (const vr of validatedRows) {
+      if (existingSet.has(vr.input.codigo)) {
+        errors.push({ row: vr.row, message: `codigo ${vr.input.codigo} already exists` })
+        continue
+      }
+      toInsert.push(vr.input)
+    }
+
+    let created = 0
+    await this.prisma.$transaction(async (tx) => {
+      for (const data of toInsert) {
+        await tx.cliente.create({ data: { ...data, tenantId } })
+        created += 1
+      }
+    })
+
+    return { created, errors }
+  }
+
+  private async persistArticulosByCodigo(
+    tenantId: number,
+    validatedRows: ValidatedImportRow<ArticuloInput>[],
+    errors: ImportRowError[],
+  ): Promise<ImportPersistResult> {
+    const codigos = validatedRows.map((r) => r.input.codigo)
+    const existing =
+      codigos.length === 0
+        ? []
+        : await this.prisma.articulo.findMany({
+            where: { tenantId, codigo: { in: codigos } },
+            select: { codigo: true },
+          })
+    const existingSet = new Set(existing.map((e) => e.codigo))
+    const toInsert: ArticuloInput[] = []
+    for (const vr of validatedRows) {
+      if (existingSet.has(vr.input.codigo)) {
+        errors.push({ row: vr.row, message: `codigo ${vr.input.codigo} already exists` })
+        continue
+      }
+      toInsert.push(vr.input)
+    }
+
+    let created = 0
+    await this.prisma.$transaction(async (tx) => {
+      for (const data of toInsert) {
+        await tx.articulo.create({ data: { ...data, tenantId } })
+        created += 1
+      }
+    })
+
+    return { created, errors }
+  }
+}

--- a/server/services/createDomainServices.ts
+++ b/server/services/createDomainServices.ts
@@ -1,0 +1,26 @@
+import type { PrismaClient } from '@prisma/client'
+import { ArticuloService } from './ArticuloService'
+import { ClienteService } from './ClienteService'
+import { FacturaService } from './FacturaService'
+import { ImportService } from './ImportService'
+
+export type DomainServices = {
+  cliente: ClienteService
+  articulo: ArticuloService
+  factura: FacturaService
+  import: ImportService
+}
+
+/**
+ * @en Builds tenant-scoped domain services for REST route handlers.
+ * @es Construye servicios de dominio por tenant para handlers REST.
+ * @pt-BR Constrói serviços de domínio por tenant para handlers REST.
+ */
+export function createDomainServices(prisma: PrismaClient): DomainServices {
+  return {
+    cliente: new ClienteService(prisma),
+    articulo: new ArticuloService(prisma),
+    factura: new FacturaService(prisma),
+    import: new ImportService(prisma),
+  }
+}

--- a/server/services/serviceResults.ts
+++ b/server/services/serviceResults.ts
@@ -1,0 +1,22 @@
+export type ServiceFailure = {
+  ok: false
+  status: number
+  error: string
+}
+
+export type ServiceSuccess<T> = {
+  ok: true
+  data: T
+}
+
+export type ServiceResult<T> = ServiceSuccess<T> | ServiceFailure
+
+export type ImportRowError = {
+  row: number
+  message: string
+}
+
+export type ImportPersistResult = {
+  created: number
+  errors: ImportRowError[]
+}

--- a/tests/server/services/articuloService.test.ts
+++ b/tests/server/services/articuloService.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+import { ArticuloService } from '../../../server/services/ArticuloService'
+
+describe('ArticuloService', () => {
+  let prisma: PrismaClient
+  let service: ArticuloService
+
+  beforeEach(() => {
+    prisma = {
+      rubro: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      articulo: {
+        count: vi.fn().mockResolvedValue(0),
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    } as unknown as PrismaClient
+    service = new ArticuloService(prisma)
+  })
+
+  it('rejects create when rubroId is not in tenant', async () => {
+    const result = await service.create(1, {
+      codigo: 20,
+      descripcion: 'Articulo test',
+      rubroId: 5,
+      condIva: '1',
+      umedida: 'UN',
+      precioLista1: 10,
+      precioLista2: 10,
+      costo: 5,
+      stock: 1,
+      minimo: 0,
+      activo: true,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(400)
+      expect(result.error).toContain('rubroId')
+    }
+    expect(prisma.articulo.create).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/services/clienteService.test.ts
+++ b/tests/server/services/clienteService.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+import { ClienteService } from '../../../server/services/ClienteService'
+
+describe('ClienteService', () => {
+  let prisma: PrismaClient
+  let service: ClienteService
+
+  beforeEach(() => {
+    prisma = {
+      deliveryZone: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      cliente: {
+        count: vi.fn().mockResolvedValue(0),
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    } as unknown as PrismaClient
+    service = new ClienteService(prisma)
+  })
+
+  it('rejects create when deliveryZoneId is not in tenant', async () => {
+    const result = await service.create(1, {
+      codigo: 10,
+      rsocial: 'Cliente SA',
+      condIva: 'RI',
+      activo: true,
+      deliveryZoneId: 99,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(400)
+      expect(result.error).toContain('deliveryZoneId')
+    }
+    expect(prisma.cliente.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when updating a missing cliente', async () => {
+    vi.mocked(prisma.cliente.findFirst).mockResolvedValue(null)
+
+    const result = await service.update(
+      1,
+      404,
+      {
+        codigo: 10,
+        rsocial: 'Cliente SA',
+        condIva: 'RI',
+        activo: true,
+      },
+      true,
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(404)
+    }
+  })
+})

--- a/tests/server/services/facturaService.test.ts
+++ b/tests/server/services/facturaService.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+import { FacturaService } from '../../../server/services/FacturaService'
+
+const baseFacturaInput = {
+  fecha: '2026-05-01',
+  tipo: 'B' as const,
+  prefijo: '0001',
+  numero: 1,
+  clienteId: 3,
+  neto1: 0,
+  neto2: 0,
+  neto3: 0,
+  iva1: 0,
+  iva2: 0,
+  total: 100,
+  items: [{ articuloId: 7, cantidad: 1, precio: 100, dscto: 0, subtotal: 100 }],
+}
+
+describe('FacturaService', () => {
+  let prisma: PrismaClient
+  let service: FacturaService
+
+  beforeEach(() => {
+    prisma = {
+      articulo: {
+        findMany: vi.fn().mockResolvedValue([{ id: 7 }]),
+      },
+      cliente: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      factura: {
+        count: vi.fn().mockResolvedValue(0),
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    } as unknown as PrismaClient
+    service = new FacturaService(prisma)
+  })
+
+  it('rejects create when clienteId is not in tenant', async () => {
+    const result = await service.create(1, baseFacturaInput)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(400)
+      expect(result.error).toContain('clienteId')
+    }
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects create when cliente is suspended', async () => {
+    vi.mocked(prisma.cliente.findFirst).mockResolvedValue({ suspended: true } as never)
+
+    const result = await service.create(1, baseFacturaInput)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(422)
+      expect(result.error).toBe('CLIENT_SUSPENDED')
+    }
+  })
+})

--- a/tests/server/services/importService.test.ts
+++ b/tests/server/services/importService.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+import { ImportService } from '../../../server/services/ImportService'
+
+describe('ImportService', () => {
+  let prisma: PrismaClient
+  let service: ImportService
+
+  beforeEach(() => {
+    prisma = {
+      cliente: {
+        findMany: vi.fn().mockResolvedValue([]),
+        create: vi.fn(),
+      },
+      $transaction: vi.fn(async (callback: (tx: PrismaClient) => Promise<void>) => callback(prisma)),
+    } as unknown as PrismaClient
+    service = new ImportService(prisma)
+  })
+
+  it('reports duplicate codigo rows during cliente import', async () => {
+    const result = await service.importClientes(1, [
+      {
+        codigo: '10',
+        rsocial: 'Uno',
+        condIva: 'RI',
+        activo: 'true',
+      },
+      {
+        codigo: '10',
+        rsocial: 'Dos',
+        condIva: 'RI',
+        activo: 'true',
+      },
+    ])
+
+    expect(result.created).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.message).toContain('Duplicate codigo 10')
+  })
+})


### PR DESCRIPTION
## Resumen

Extrae la logica de negocio de clientes, articulos, facturas e importaciones CSV a servicios inyectados via RestRouteContext.services (createDomainServices). Los handlers conservan permisos, validacion Zod, auditoria y dispatchNotification en facturas.

Closes #90

## Cambios

- server/services: ClienteService, ArticuloService, FacturaService, ImportService, createDomainServices, serviceResults.
- Rutas delgadas en registerClientes/Articulos/Facturas.
- tests/server/services: pruebas unitarias con Prisma mock.

## Fuera de alcance

- Rubros, proveedores y zonas siguen con logica en handlers.

## Verificacion local

- npm run type-check
- npm run lint
- npm run test (443 tests)
- npm run test:integration (9 tests)
- npx prisma validate

Made with [Cursor](https://cursor.com)