### PR TITLE
docs(quality): triage wave 1 OpenAPI and docs-map

### DIFF
--- a/docs/en/quality/ci-cd.md
+++ b/docs/en/quality/ci-cd.md
@@ -21,7 +21,7 @@ push / pull_request
 │  5. npx prisma validate       ← schema syntax / metadata (no DB write) │
 │  6. npx prisma migrate deploy  ← schema on PostgreSQL       │
 │  7. npm run type-check                      ← blocks         │
-│  7b. npm run check:openapi                 ← blocks         │
+│  7b. npm run docs:validate                 ← blocks         │
 │  8. npm run docs:generate                  ← blocks         │
 │  9. git diff (generated docs / SBOM check) ← blocks         │
 │ 10. npm run lint                           ← blocks         │
@@ -62,7 +62,7 @@ push / pull_request
 | Surface | Evidence / behavior checked | Typical workflow(s) |
 |---|---|---|
 | TypeScript compilation | Whole repo `tsconfig` include (`src`, `server`, `tests`, `e2e`, …) | `ci.yml` → `npm run type-check` |
-| REST API vs contract | OpenAPI YAML + regenerated schemas / MD drift | `ci.yml` → `check:openapi`, `docs:generate`, git diff |
+| REST API vs contract | OpenAPI YAML syntax + route sync + regenerated schemas / MD drift | `ci.yml` → `docs:validate`, `docs:generate`, git diff |
 | Database schema lifecycle | Client generation, validated schema file, migrations or `db push`, seed used by runtime tests | `ci.yml` → `prisma generate`, `prisma validate`, migrate/push + `test:integration`; `backend-validation.yml` (paths) adds DB migration smoke |
 | Line / branch metrics (coverage) | **`vitest` v8 thresholds** apply only to **`server/**/*.ts`**, root `server.ts`, and **`src/**/*.{ts,tsx}`**, excluding tests, barrels, typings, and `server/main.ts`/`server/createApp.types.ts`/`src/types.ts` via `coverage.exclude`. **Not everything in repo** (scripts, prisma seed, standalone tools) file: `vitest.config.ts` | `ci.yml`, `frontend-validation.yml`, `qa-validation.yml` → `npm run test:coverage` |
 | Integration with PostgreSQL | Real DB paths in `tests/integration/**`; **explicitly without line-coverage instrumentation** (`vitest.integration.config.ts`) | `ci.yml`, `backend-validation.yml` |

--- a/docs/en/quality/testing-strategy.md
+++ b/docs/en/quality/testing-strategy.md
@@ -51,6 +51,7 @@ Thresholds are enforced by Vitest's `coverage.thresholds` configuration. The CI 
 | Lint (incl. jsx-a11y) | `npm run lint` | `ci.yml`, `frontend-validation.yml` |
 | Unit + coverage | `npm run test`, `npm run test:coverage` | `ci.yml`, `qa-validation.yml` (`unit_tests`) |
 | API contract | part of `npm run test` | `ci.yml` |
+| OpenAPI syntax + route sync | `npm run docs:validate` | `ci.yml` |
 | Integration | `npm run test:integration` (needs `DATABASE_URL`) | `ci.yml`, `qa-validation.yml` (`integration_tests`) |
 | E2E Playwright | `npm run test:e2e` (uses `playwright.config.ts` webServer) | `ci.yml`, `qa-validation.yml` (`e2e_tests`) |
 | A11y unit smoke | `npm run test:a11y` | `qa-validation.yml` (`accessibility_tests`) |

--- a/docs/es/quality/ciclo-ci-cd.md
+++ b/docs/es/quality/ciclo-ci-cd.md
@@ -9,7 +9,7 @@ BizCode usa GitHub Actions para integración continua. El pipeline está definid
 ```
 push / pull_request → job quality (ubuntu-latest):
   checkout → Node 22 → npm ci → npm audit (informativo) → prisma generate → prisma validate → prisma migrate deploy →
-  type-check → check:openapi → docs:generate → git diff (docs generados / SBOM) → lint → test:coverage → check:i18n →
+  type-check → docs:validate → docs:generate → git diff (docs generados / SBOM) → lint → test:coverage → check:i18n →
   playwright install chromium → test:e2e → test:integration → check:docs-map →
   artefacto de cobertura
 ```
@@ -29,7 +29,7 @@ Un paso bloquea el pipeline (código de salida ≠ 0) cuando:
 |---|---|
 | prisma validate | `schema.prisma` inválido según Prisma (sin mutar PostgreSQL) |
 | type-check | Cualquier error de compilación TypeScript |
-| check:openapi | Fallo de validación OpenAPI 3.x sobre `docs/api/openapi.yaml` (`npm run check:openapi`) |
+| docs:validate | Sintaxis OpenAPI 3.x (`npm run check:openapi`) y cobertura de rutas Express `/api/*` en `docs/api/openapi.yaml` (`npm run check:openapi-sync`) |
 | docs:generate + git diff | Desalineación entre lo commitado y la documentación regenerada (`docs/generated/`, `docs/api/openapi-reference.generated.md`, `docs/evidence/sbom-cyclonedx.json`) |
 | lint | Cualquier error o **advertencia** de ESLint (`npm run lint` usa `--max-warnings 0`) |
 | test:coverage | Fallo de test O umbral de cobertura no cumplido |
@@ -43,7 +43,7 @@ Un paso bloquea el pipeline (código de salida ≠ 0) cuando:
 | Superficie | Qué se verifica | Workflow(s) típico(s) |
 |---|---|---|
 | Compilación TypeScript | Árbol completo del `tsconfig` (`src`, `server`, `tests`, `e2e`, …) | `ci.yml` → `npm run type-check` |
-| API vs contrato | OpenAPI + drift de esquemas / MD generados | `ci.yml` → `check:openapi`, `docs:generate`, `git diff` |
+| API vs contrato | Sintaxis OpenAPI + sync de rutas + drift de esquemas / MD generados | `ci.yml` → `docs:validate`, `docs:generate`, `git diff` |
 | Ciclo de vida del esquema BD | `prisma generate`, `prisma validate`, migraciones o `db push`, seed usado en pruebas | `ci.yml`; `backend-validation.yml` (rutas) refuerzo de migraciones |
 | Cobertura de líneas/ramas (Vitest/v8) | Umbrales sobre **`server/**/*.ts`**, `server.ts` y **`src/**/*.{ts,tsx}`**, excluyendo tests, barrels solo re-export y tipados (`coverage.exclude` en `vitest.config.ts`). **No todo el repo** (scripts auxiliares, seed aislado, etc.) no entra | `ci.yml`, `frontend-validation.yml`, `qa-validation.yml` → `test:coverage` |
 | Integración PostgreSQL | `tests/integration/**` **sin instrumentación de cobertura de líneas** (`vitest.integration.config.ts`) | `ci.yml`, `backend-validation.yml` |

--- a/docs/es/quality/estrategia-pruebas.md
+++ b/docs/es/quality/estrategia-pruebas.md
@@ -51,6 +51,7 @@ Los umbrales los aplica Vitest (`coverage.thresholds`). El CI falla si no se cum
 | Lint (incl. jsx-a11y) | `npm run lint` | `ci.yml`, `frontend-validation.yml` |
 | Unitarias + cobertura | `npm run test`, `npm run test:coverage` | `ci.yml`, `qa-validation.yml` (job `unit_tests`) |
 | Contrato API | parte de `npm run test` | `ci.yml` |
+| Sintaxis OpenAPI + sync de rutas | `npm run docs:validate` | `ci.yml` |
 | Integración | `npm run test:integration` (requiere `DATABASE_URL`) | `ci.yml`, `qa-validation.yml` |
 | E2E Playwright | `npm run test:e2e` | `ci.yml`, `qa-validation.yml` |
 | A11y unitaria | `npm run test:a11y` | `qa-validation.yml` (`accessibility_tests`) |

--- a/docs/pt-br/quality/ciclo-ci-cd.md
+++ b/docs/pt-br/quality/ciclo-ci-cd.md
@@ -9,7 +9,7 @@ BizCode usa GitHub Actions. Definição: `.github/workflows/ci.yml`.
 ```
 push / pull_request → job quality (ubuntu-latest):
   checkout → Node 22 → npm ci → npm audit (informativo) → prisma generate → prisma validate → prisma migrate deploy →
-  type-check → check:openapi → docs:generate → git diff (docs gerados / SBOM) → lint → test:coverage → check:i18n →
+  type-check → docs:validate → docs:generate → git diff (docs gerados / SBOM) → lint → test:coverage → check:i18n →
   playwright install chromium → test:e2e → test:integration → check:docs-map →
   artefato de cobertura
 ```
@@ -27,7 +27,7 @@ push / pull_request → job quality (ubuntu-latest):
 |---|---|
 | prisma validate | `schema.prisma` inválido segundo Prisma (sem gravar PostgreSQL) |
 | type-check | Erro TypeScript |
-| check:openapi | Falha na validação OpenAPI 3.x de `docs/api/openapi.yaml` (`npm run check:openapi`) |
+| docs:validate | Sintaxe OpenAPI 3.x (`npm run check:openapi`) e cobertura de rotas Express `/api/*` em `docs/api/openapi.yaml` (`npm run check:openapi-sync`) |
 | docs:generate + git diff | Divergência entre arquivos commitados e documentação regenerada (`docs/generated/`, `docs/api/openapi-reference.generated.md`, `docs/evidence/sbom-cyclonedx.json`) |
 | lint | Erro ou **warning** ESLint (`--max-warnings 0`) |
 | test:coverage | Falha de teste ou cobertura abaixo do limite |
@@ -41,7 +41,7 @@ push / pull_request → job quality (ubuntu-latest):
 | Superfície | Evidência / comportamento | Workflow(s) |
 |---|---|---|
 | TypeScript compilando | Projeto inteiro segundo `tsconfig` (`src`, `server`, `tests`, `e2e`, …) | `ci.yml` → `npm run type-check` |
-| API × contrato | OpenAPI YAML + artefatos regenerados consistentes | `ci.yml` → `check:openapi`, `docs:generate`, git diff |
+| API × contrato | Sintaxe OpenAPI + sync de rotas + artefatos regenerados consistentes | `ci.yml` → `docs:validate`, `docs:generate`, git diff |
 | Esquema de BD | `prisma generate`, `prisma validate`, migrations ou `db push`, seeds usados nos testes | `ci.yml`; `backend-validation.yml` (filtros de caminho) reforço de migrations |
 | Cobertura de linhas/ramificações | Vitest v8 apenas em **`server/**/*.ts`**, `server.ts` e **`src/**/*.{ts,tsx}`**, com exclusões em `coverage.exclude` de `vitest.config.ts`; **nem todo arquivo** da raiz está instrumentado | `ci.yml`, `frontend-validation.yml`, `qa-validation.yml` → `test:coverage` |
 | Integração PostgreSQL | `tests/integration/**`, **sem instrumentação de linhas** (`vitest.integration.config.ts`) | `ci.yml`, `backend-validation.yml` |

--- a/docs/pt-br/quality/estrategia-testes.md
+++ b/docs/pt-br/quality/estrategia-testes.md
@@ -51,6 +51,7 @@ Os limiares são aplicados pelo Vitest (`coverage.thresholds`). O CI falha se n�
 | Lint (incl. jsx-a11y) | `npm run lint` | `ci.yml`, `frontend-validation.yml` |
 | Unitários + cobertura | `npm run test`, `npm run test:coverage` | `ci.yml`, `qa-validation.yml` (`unit_tests`) |
 | Contrato API | parte de `npm run test` | `ci.yml` |
+| Sintaxe OpenAPI + sync de rotas | `npm run docs:validate` | `ci.yml` |
 | Integração | `npm run test:integration` (precisa `DATABASE_URL`) | `ci.yml`, `qa-validation.yml` |
 | E2E Playwright | `npm run test:e2e` | `ci.yml`, `qa-validation.yml` |
 | A11y unitário | `npm run test:a11y` | `qa-validation.yml` (`accessibility_tests`) |


### PR DESCRIPTION
## Summary

- Align CI and testing strategy docs (EN/ES/PT-BR) with \
pm run docs:validate\ (\check:openapi\ + \check:openapi-sync\).
- Evidence for closing #70, #91; #76 duplicate of #91.

## Verification

- npm run check:docs-map
- npm run docs:validate
- npm run test

Made with [Cursor](https://cursor.com)