### PR TITLE
ci(tauri): tagged multi-OS release workflow (issue #71)

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,0 +1,63 @@
+# Tagged desktop releases (Tauri). Complements manual self-hosted builds in ADR-0006.
+name: Tauri release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+          - platform: windows-latest
+          - platform: macos-latest
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev librsvg2-dev patchelf
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build and upload release assets
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: BizCode ${{ github.ref_name }}
+          releaseBody: Desktop installers built from tag ${{ github.ref_name }}.
+          releaseDraft: true
+          prerelease: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,4 +113,4 @@ npm run test:integration    # HTTP + real Prisma vs PostgreSQL; requires DATABAS
 
 All must exit 0 before opening a PR. If you do not run PostgreSQL locally, rely on CI for `test:integration`; contract + unit coverage do not require a database.
 
-`npm run server` executes `tsx server/main.ts` (API bootstrap is in `server.ts`; see [ADR-0005](docs/en/adr/ADR-0005-vitest-coverage-server-bootstrap.md)). Optional release workflows: [ADR-0006](docs/en/adr/ADR-0006-release-and-tauri-ci-workflows.md).
+`npm run server` executes `tsx server/main.ts` (API bootstrap is in `server.ts`; see [ADR-0005](docs/en/adr/ADR-0005-vitest-coverage-server-bootstrap.md)). Optional release workflows: [ADR-0006](docs/en/adr/ADR-0006-release-and-tauri-ci-workflows.md) (`release.yml`, `tauri-selfhosted.yml`, and tagged desktop builds via `tauri-release.yml` on `v*.*.*` tags).

--- a/docs/en/adr/ADR-0006-release-and-tauri-ci-workflows.md
+++ b/docs/en/adr/ADR-0006-release-and-tauri-ci-workflows.md
@@ -15,6 +15,7 @@ The default pipeline ([ci-cd.md](../quality/ci-cd.md)) blocks on quality gates; 
 1. **`npm audit`:** GitHub Actions runs `npm audit --audit-level=high` after `npm ci` with **`continue-on-error: true`** so vulnerabilities are visible without failing the gate until the team resolves them.
 2. **semantic-release:** `release.config.cjs` at the repo root; workflow `.github/workflows/release.yml` runs **only** on **`workflow_dispatch`**, creates GitHub Releases from [Conventional Commits](https://www.conventionalcommits.org/) on `main` using the default `GITHUB_TOKEN`. No npm publish (package is `private`).
 3. **Tauri self-hosted:** workflow `.github/workflows/tauri-selfhosted.yml` runs **only** on **`workflow_dispatch`** on **`runs-on: self-hosted`**. The runner must provide Rust, Node, and platform-native WebView dependencies (see [ci-cd.md](../quality/ci-cd.md)) — the workflow does **not** run on `ubuntu-latest` in the default job.
+4. **Tauri tagged releases:** workflow `.github/workflows/tauri-release.yml` runs on **`push` tags `v*.*.*`**, building installers on GitHub-hosted `ubuntu-latest`, `windows-latest`, and `macos-latest` and uploading draft release assets. Code signing and notarization remain optional via repository secrets and are not required for the workflow to run.
 
 ## Consequences
 
@@ -30,4 +31,4 @@ The default pipeline ([ci-cd.md](../quality/ci-cd.md)) blocks on quality gates; 
 ## References
 
 - [quality/ci-cd.md](../quality/ci-cd.md)
-- `release.config.cjs`, `.github/workflows/release.yml`, `.github/workflows/tauri-selfhosted.yml`
+- `release.config.cjs`, `.github/workflows/release.yml`, `.github/workflows/tauri-selfhosted.yml`, `.github/workflows/tauri-release.yml`

--- a/docs/en/quality/ci-cd.md
+++ b/docs/en/quality/ci-cd.md
@@ -86,7 +86,7 @@ The job starts a **PostgreSQL 16** service container (`DATABASE_URL` is set). Af
 
 **Tauri desktop build** is excluded from CI (native WebKit/WebView2, display server, Rust toolchain). See workflow comments in `.github/workflows/ci.yml`.
 
-**Manual release gate (desktop binaries):** after `main` is green, invoke **Actions → Tauri self-hosted build** (`tauri-selfhosted.yml`) before shipping installers; semantic-release tagging remains separate (`release.yml`). See [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
+**Manual release gate (desktop binaries):** after `main` is green, invoke **Actions → Tauri self-hosted build** (`tauri-selfhosted.yml`) before shipping installers; tagged releases can also use **Actions → Tauri release** (`tauri-release.yml` on `v*.*.*` tags). See [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
 
 ## Documentation branch (`documentacion`)
 

--- a/docs/es/adr/ADR-0006-release-and-tauri-ci-workflows.md
+++ b/docs/es/adr/ADR-0006-release-and-tauri-ci-workflows.md
@@ -15,6 +15,7 @@ El pipeline por defecto ([ciclo-ci-cd.md](../quality/ciclo-ci-cd.md)) no publica
 1. **`npm audit`:** el workflow ejecuta `npm audit --audit-level=high` tras `npm ci` con **`continue-on-error: true`** para visibilidad sin fallar el gate.
 2. **semantic-release:** `release.config.cjs` en la raíz; `.github/workflows/release.yml` solo con **`workflow_dispatch`**, crea GitHub Releases desde commits convencionales en `main` con `GITHUB_TOKEN`. Sin publicación npm (paquete `private`).
 3. **Tauri self-hosted:** `.github/workflows/tauri-selfhosted.yml` solo **`workflow_dispatch`** en **`runs-on: self-hosted`**. El runner debe tener Rust, Node y dependencias WebView nativas — no sustituye el job de calidad en `ubuntu-latest`.
+4. **Releases Tauri por tag:** `.github/workflows/tauri-release.yml` en **`push` de tags `v*.*.*`**, matriz en runners alojados de GitHub y artefactos en borrador de release; firma/notarización opcional vía secrets.
 
 ## Consecuencias
 

--- a/docs/es/quality/ciclo-ci-cd.md
+++ b/docs/es/quality/ciclo-ci-cd.md
@@ -73,7 +73,7 @@ El job inicia **PostgreSQL 16** (`DATABASE_URL` configurada). Tras `prisma migra
 
 **Alternativa:** build local con `npm run tauri build` o `npm run tauri dev`.
 
-**Gate manual de escritorio:** una vez **`main`** verde, ejecutar **Actions → build Tauri self-hosted** (`tauri-selfhosted.yml`) antes de publicar instaladores; el tagging con semantic-release permanece aparte (`release.yml`). Detalle: [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
+**Gate manual de escritorio:** una vez **`main`** verde, ejecutar **Actions → build Tauri self-hosted** (`tauri-selfhosted.yml`) antes de publicar instaladores; también puede usarse **Actions → Tauri release** (`tauri-release.yml` en tags `v*.*.*`). Detalle: [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
 
 ## Rama huérfana `documentacion`
 

--- a/docs/pt-br/adr/ADR-0006-release-and-tauri-ci-workflows.md
+++ b/docs/pt-br/adr/ADR-0006-release-and-tauri-ci-workflows.md
@@ -15,6 +15,7 @@ O pipeline padrão ([ciclo-ci-cd.md](../quality/ciclo-ci-cd.md)) não publica re
 1. **`npm audit`:** o workflow executa `npm audit --audit-level=high` após `npm ci` com **`continue-on-error: true`**.
 2. **semantic-release:** `release.config.cjs` na raiz; `.github/workflows/release.yml` apenas **`workflow_dispatch`**, cria GitHub Releases a partir de commits convencionais em `main` com `GITHUB_TOKEN`. Sem publicação npm (`private`).
 3. **Tauri self-hosted:** `.github/workflows/tauri-selfhosted.yml` apenas **`workflow_dispatch`** em **`runs-on: self-hosted`**. O runner precisa de Rust, Node e dependências WebView nativas.
+4. **Releases Tauri por tag:** `.github/workflows/tauri-release.yml` em **`push` de tags `v*.*.*`**, matriz em runners hospedados do GitHub e artefatos em release rascunho; assinatura/notarização opcional via secrets.
 
 ## Consequências
 

--- a/docs/pt-br/quality/ciclo-ci-cd.md
+++ b/docs/pt-br/quality/ciclo-ci-cd.md
@@ -63,7 +63,7 @@ push / pull_request → job quality (ubuntu-latest):
 
 Build desktop Tauri (WebKit nativo, display, Rust). Build local: `npm run tauri build`.
 
-**Gate manual (desktop):** após **`main`** verde, executar **Actions → Tauri self-hosted** (`tauri-selfhosted.yml`) antes de distribuir instaladores; tags via semantic-release seguem isoladas (`release.yml`). Referência [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
+**Gate manual (desktop):** após **`main`** verde, executar **Actions → Tauri self-hosted** (`tauri-selfhosted.yml`) antes de distribuir instaladores; releases por tag podem usar **Actions → Tauri release** (`tauri-release.yml` em tags `v*.*.*`). Referência [ADR-0006](../adr/ADR-0006-release-and-tauri-ci-workflows.md).
 
 ## Branch órfão `documentacion`
 


### PR DESCRIPTION
Closes #71. Adds tauri-release.yml on v* tags, documents ADR-0006 and CI/CD in three locales.

Made with [Cursor](https://cursor.com)