### PR TITLE
docs(migration): align issue #51 CLIENTES ETL documentation

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -10,6 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **DBF customer migration (GitHub #51):** `npm run migrate:dbf` imports customers from `CLIENTES.DBF` when the file exists with rows (`legacyClienteDbf.ts`, `clienteBodySchema`, rejection report); placeholders `91001`–`91010` only without a populated master; see [DBF migration testing](guides/dbf-migration-testing.md) and `scripts/MIGRACION_PROGRAMA_VIEJO.md`. Bulk load in the app uses CSV import (#58).
+
 - **SaaS plans and per-tenant limits (GitHub #181):** `Plan` / `TenantPlan` models; `GET /api/planes`, `GET /api/me/plan`, `POST /api/superadmin/tenants/:id/plan`; `requirePlanFeature`; limits on `POST /api/users` and `POST /api/facturas`; `PlanProvider`, `PlanGate`, SuperAdmin plan selector; i18n EN/ES/PT-BR.
 
 - **SuperAdmin module pricing and trials (GitHub #226):** `GET /api/superadmin/tenants/:id/pricing`, `GET/POST/DELETE .../trials`; `TenantModuleTrial` model; `src/lib/modules/pricing.ts`, `TenantPricingService`, `TenantTrialService`; `npm run modules:trial-expire`; notification type `module_trial_expiring`; pricing/trial UI on `/superadmin/tenants/:id/modules`; OpenAPI and API tests; i18n EN/ES/PT-BR (billing sync deferred to #181).

--- a/docs/en/guides/dbf-migration-testing.md
+++ b/docs/en/guides/dbf-migration-testing.md
@@ -1,6 +1,16 @@
 # DBF migration testing
 
-This guide documents the harness used to validate `scripts/migrate-from-dbf.ts` without a production `CLIENTES.DBF` source.
+This guide documents the harness used to validate `scripts/migrate-from-dbf.ts` without requiring a production legacy tree on every machine.
+
+## CLIENTES ETL status (#51)
+
+Implemented in PR #120 (GitHub issue #51):
+
+- Pure mapping: [`src/lib/migration/legacyClienteDbf.ts`](../../../src/lib/migration/legacyClienteDbf.ts).
+- Orchestration: [`scripts/migrate-from-dbf.ts`](../../../scripts/migrate-from-dbf.ts) (`npm run migrate:dbf`).
+- Contract: `clienteBodySchema` (same as REST and CSV import).
+- When `CLIENTES.DBF` exists under `PROGRAMA_VIEJO_ROOT/…/sistema/` with `recordCount > 0`, real rows are imported; otherwise the script keeps **10 placeholders** `91001`–`91010`. See [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md).
+- Production runs need an agreed legacy copy on disk; bulk load for new installs in the app uses CSV import (issue #58), which does not replace on-demand DBF migration.
 
 ## Fixtures
 
@@ -9,10 +19,12 @@ This guide documents the harness used to validate `scripts/migrate-from-dbf.ts` 
 
 ## Integration
 
-- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + generated PVAR/PVAR2/LIST_CLI fixtures; asserts placeholder client import and product rows.
+- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + generated DBF fixtures; two paths:
+  - **Without `CLIENTES.DBF`:** PVAR/PVAR2/LIST_CLI fixtures; asserts placeholder clients (`91001`–`91010`) and imported products.
+  - **With `CLIENTES.DBF`:** fixture tree with valid/invalid `COND` rows; asserts real client import and **no** placeholders.
 - Requires `DATABASE_URL` (`npm run test:integration`).
 
 ## Related docs
 
-- `scripts/MIGRACION_PROGRAMA_VIEJO.md`
-- Issue #51 remains blocked for production CLIENTES ETL until a verified DBF source is agreed.
+- [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md)
+- [`docs/referencias/05-mapeo-tablas-legacy-a-bizcode.md`](../../referencias/05-mapeo-tablas-legacy-a-bizcode.md)

--- a/docs/en/quality/master-plan-bizcode-execution.md
+++ b/docs/en/quality/master-plan-bizcode-execution.md
@@ -51,7 +51,7 @@ Priorities below are **planning** items; verification is against the repository 
 | BP1-2 | P1 | E2E / integration coverage for critical paths | **Done (#66):** `e2e/critical-paths.spec.ts` + CI; extend per [testing-strategy.md](testing-strategy.md) if more flows are required |
 | BP1-3 | P1 | Channel scope enforcement | **Implemented in current codebase:** `requirePermission` in [`server/auth.ts`](../../../server/auth.ts) validates optional `x-bizcode-channel` against `AuthScope.channels`; invalid header returns `400`, out-of-scope returns `403`. Covered by [`tests/server/scope-channel.test.ts`](../../../tests/server/scope-channel.test.ts) |
 | BP1-4 | P1 | Internal chat (minimum scope) | Implemented with `/api/chat/conversations`, `/api/chat/messages`, unread counters via `Notification` (`chat_message`), paginated message history, and UI route `/chat` in `src/pages/chat/index.tsx` |
-| BP1-5 | P1 | DBF customer ETL readiness (#51) | Discovery documented in `scripts/MIGRACION_PROGRAMA_VIEJO.md` (explicit `COND`/`BAJA`/`CREDITO` mapping and rejection policy); no production customer ETL implementation in this phase |
+| BP1-5 | P1 | DBF customer ETL (#51) | **Done (PR #120):** v1 ETL from `CLIENTES.DBF` via `legacyClienteDbf.ts` + `migrate-from-dbf.ts` with `clienteBodySchema`; mapping and rejection policy in `scripts/MIGRACION_PROGRAMA_VIEJO.md`; placeholders `91001`–`91010` only when no master file with rows; v1 out of scope: `SALDO`, `FPAGO`, `ZONA` |
 
 ## Repository status vs this package
 

--- a/docs/es/guides/pruebas-migracion-dbf.md
+++ b/docs/es/guides/pruebas-migracion-dbf.md
@@ -1,6 +1,16 @@
 # Pruebas de migración DBF
 
-Esta guía documenta el harness para validar `scripts/migrate-from-dbf.ts` sin una fuente productiva `CLIENTES.DBF`.
+Esta guía documenta el harness para validar `scripts/migrate-from-dbf.ts` sin exigir en cada máquina una copia productiva del árbol legacy.
+
+## Estado ETL CLIENTES (#51)
+
+Implementado en PR #120 (issue GitHub #51):
+
+- Mapeo puro: [`src/lib/migration/legacyClienteDbf.ts`](../../../src/lib/migration/legacyClienteDbf.ts).
+- Orquestación: [`scripts/migrate-from-dbf.ts`](../../../scripts/migrate-from-dbf.ts) (`npm run migrate:dbf`).
+- Contrato: `clienteBodySchema` (mismo que REST e importación CSV).
+- Si `CLIENTES.DBF` existe bajo `PROGRAMA_VIEJO_ROOT/…/sistema/` con `recordCount > 0`, se importan filas reales; si no, el script mantiene **10 placeholders** `91001`–`91010`. Ver [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md).
+- En producción hace falta una copia legacy acordada en disco; la carga masiva en instalaciones nuevas usa importación CSV en la app (issue #58), que no sustituye la migración DBF bajo demanda.
 
 ## Fixtures
 
@@ -9,10 +19,12 @@ Esta guía documenta el harness para validar `scripts/migrate-from-dbf.ts` sin u
 
 ## Integración
 
-- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + fixtures PVAR/PVAR2/LIST_CLI generados; verifica clientes placeholder y artículos importados.
+- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + fixtures DBF generados; dos recorridos:
+  - **Sin `CLIENTES.DBF`:** fixtures PVAR/PVAR2/LIST_CLI; verifica clientes placeholder (`91001`–`91010`) y artículos importados.
+  - **Con `CLIENTES.DBF`:** árbol con filas `COND` válidas e inválidas; verifica importación real y **ausencia** de placeholders.
 - Requiere `DATABASE_URL` (`npm run test:integration`).
 
 ## Documentación relacionada
 
-- `scripts/MIGRACION_PROGRAMA_VIEJO.md`
-- El issue #51 sigue bloqueado para ETL productivo de CLIENTES hasta acordar una fuente DBF verificada.
+- [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md)
+- [`docs/referencias/05-mapeo-tablas-legacy-a-bizcode.md`](../../referencias/05-mapeo-tablas-legacy-a-bizcode.md)

--- a/docs/es/historial-de-cambios.md
+++ b/docs/es/historial-de-cambios.md
@@ -10,6 +10,8 @@ Versionado: [Semantic Versioning](https://semver.org/lang/es/).
 
 ### Agregado
 
+- **Migración DBF de clientes (GitHub #51):** `npm run migrate:dbf` importa clientes desde `CLIENTES.DBF` cuando el archivo existe con filas (`legacyClienteDbf.ts`, `clienteBodySchema`, informe de rechazos); placeholders `91001`–`91010` solo sin maestro poblado; ver [Pruebas de migración DBF](guides/pruebas-migracion-dbf.md) y `scripts/MIGRACION_PROGRAMA_VIEJO.md`. Carga masiva en la app vía importación CSV (#58).
+
 - **Planes SaaS y límites por tenant (GitHub #181):** modelos `Plan` / `TenantPlan`; `GET /api/planes`, `GET /api/me/plan`, `POST /api/superadmin/tenants/:id/plan`; `requirePlanFeature`; límites en `POST /api/users` y `POST /api/facturas`; `PlanProvider`, `PlanGate`, selector en detalle SuperAdmin; i18n EN/ES/PT-BR.
 
 - **Pricing y trials de módulos SuperAdmin (GitHub #226):** `GET /api/superadmin/tenants/:id/pricing`, `GET/POST/DELETE .../trials`; modelo `TenantModuleTrial`; `src/lib/modules/pricing.ts`, `TenantPricingService`, `TenantTrialService`; `npm run modules:trial-expire`; notificación `module_trial_expiring`; UI pricing/trial en `/superadmin/tenants/:id/modules`; OpenAPI y tests API; i18n EN/ES/PT-BR (sync billing diferido a #181).

--- a/docs/es/quality/ejecucion-plan-maestro-bizcode.md
+++ b/docs/es/quality/ejecucion-plan-maestro-bizcode.md
@@ -51,7 +51,7 @@ Las prioridades siguientes son ítems de **planificación**; la verificación es
 | BP1-2 | P1 | Cobertura E2E / integración de caminos críticos | **Hecho (#66):** `e2e/critical-paths.spec.ts` + CI; ampliar según estrategia si se exigen más flujos |
 | BP1-3 | P1 | Refuerzo de alcance por canal | **Implementado en el código actual:** `requirePermission` en [`server/auth.ts`](../../../server/auth.ts) valida `x-bizcode-channel` opcional contra `AuthScope.channels`; cabecera inválida devuelve `400` y canal fuera de alcance devuelve `403`. Cubierto por [`tests/server/scope-channel.test.ts`](../../../tests/server/scope-channel.test.ts) |
 | BP1-4 | P1 | Chat interno (alcance mínimo) | Implementado con `/api/chat/conversations`, `/api/chat/messages`, contador de no leídos vía `Notification` (`chat_message`), historial paginado y ruta UI `/chat` en `src/pages/chat/index.tsx` |
-| BP1-5 | P1 | Preparación ETL clientes DBF (#51) | Relevamiento documentado en `scripts/MIGRACION_PROGRAMA_VIEJO.md` (mapeo explícito `COND`/`BAJA`/`CREDITO` y política de rechazo); sin implementación productiva de ETL de clientes en esta fase |
+| BP1-5 | P1 | ETL clientes DBF (#51) | **Hecho (PR #120):** ETL v1 desde `CLIENTES.DBF` con `legacyClienteDbf.ts` + `migrate-from-dbf.ts` y `clienteBodySchema`; mapeo y rechazos en `scripts/MIGRACION_PROGRAMA_VIEJO.md`; placeholders `91001`–`91010` solo sin maestro con filas; fuera de alcance v1: `SALDO`, `FPAGO`, `ZONA` |
 
 ## Estado del repositorio vs este paquete
 

--- a/docs/pt-br/guides/testes-migracao-dbf.md
+++ b/docs/pt-br/guides/testes-migracao-dbf.md
@@ -1,6 +1,16 @@
 # Testes de migração DBF
 
-Este guia documenta o harness para validar `scripts/migrate-from-dbf.ts` sem uma fonte produtiva `CLIENTES.DBF`.
+Este guia documenta o harness para validar `scripts/migrate-from-dbf.ts` sem exigir em cada máquina uma cópia produtiva da árvore legacy.
+
+## Status ETL CLIENTES (#51)
+
+Implementado no PR #120 (issue GitHub #51):
+
+- Mapeamento puro: [`src/lib/migration/legacyClienteDbf.ts`](../../../src/lib/migration/legacyClienteDbf.ts).
+- Orquestração: [`scripts/migrate-from-dbf.ts`](../../../scripts/migrate-from-dbf.ts) (`npm run migrate:dbf`).
+- Contrato: `clienteBodySchema` (mesmo que REST e importação CSV).
+- Quando `CLIENTES.DBF` existe em `PROGRAMA_VIEJO_ROOT/…/sistema/` com `recordCount > 0`, linhas reais são importadas; caso contrário, o script mantém **10 placeholders** `91001`–`91010`. Ver [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md).
+- Em produção é necessária uma cópia legacy acordada em disco; carga em massa em instalações novas usa importação CSV no app (issue #58), que não substitui a migração DBF sob demanda.
 
 ## Fixtures
 
@@ -9,10 +19,12 @@ Este guia documenta o harness para validar `scripts/migrate-from-dbf.ts` sem uma
 
 ## Integração
 
-- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + fixtures PVAR/PVAR2/LIST_CLI gerados; verifica clientes placeholder e artigos importados.
+- `tests/integration/dbf-migration.integration.test.ts` — PostgreSQL + fixtures DBF gerados; dois fluxos:
+  - **Sem `CLIENTES.DBF`:** fixtures PVAR/PVAR2/LIST_CLI; verifica clientes placeholder (`91001`–`91010`) e artigos importados.
+  - **Com `CLIENTES.DBF`:** árvore com linhas `COND` válidas e inválidas; verifica importação real e **ausência** de placeholders.
 - Requer `DATABASE_URL` (`npm run test:integration`).
 
 ## Documentação relacionada
 
-- `scripts/MIGRACION_PROGRAMA_VIEJO.md`
-- O issue #51 permanece bloqueado para ETL produtivo de CLIENTES até haver fonte DBF verificada.
+- [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../../scripts/MIGRACION_PROGRAMA_VIEJO.md)
+- [`docs/referencias/05-mapeo-tablas-legacy-a-bizcode.md`](../../referencias/05-mapeo-tablas-legacy-a-bizcode.md)

--- a/docs/pt-br/historico-de-alteracoes.md
+++ b/docs/pt-br/historico-de-alteracoes.md
@@ -10,6 +10,8 @@ Versionamento: [Semantic Versioning](https://semver.org/).
 
 ### Adicionado
 
+- **Migração DBF de clientes (GitHub #51):** `npm run migrate:dbf` importa clientes de `CLIENTES.DBF` quando o arquivo existe com linhas (`legacyClienteDbf.ts`, `clienteBodySchema`, relatório de rejeições); placeholders `91001`–`91010` apenas sem mestre populado; ver [Testes de migração DBF](guides/testes-migracao-dbf.md) e `scripts/MIGRACION_PROGRAMA_VIEJO.md`. Carga em massa no app via importação CSV (#58).
+
 - **Planos SaaS e limites por tenant (GitHub #181):** modelos `Plan` / `TenantPlan`; `GET /api/planes`, `GET /api/me/plan`, `POST /api/superadmin/tenants/:id/plan`; `requirePlanFeature`; limites em `POST /api/users` e `POST /api/facturas`; `PlanProvider`, `PlanGate`, seletor no detalhe SuperAdmin; i18n EN/ES/PT-BR.
 
 - **Pricing e trials de módulos SuperAdmin (GitHub #226):** `GET /api/superadmin/tenants/:id/pricing`, `GET/POST/DELETE .../trials`; modelo `TenantModuleTrial`; `src/lib/modules/pricing.ts`, `TenantPricingService`, `TenantTrialService`; `npm run modules:trial-expire`; notificação `module_trial_expiring`; UI pricing/trial em `/superadmin/tenants/:id/modules`; OpenAPI e testes API; i18n EN/ES/PT-BR (sync billing adiado para #181).

--- a/docs/pt-br/quality/execucao-plano-mestre-bizcode.md
+++ b/docs/pt-br/quality/execucao-plano-mestre-bizcode.md
@@ -51,7 +51,7 @@ As prioridades abaixo são itens de **planejamento**; a verificação é contra 
 | BP1-2 | P1 | Cobertura E2E / integração de fluxos críticos | **Feito (#66):** `e2e/critical-paths.spec.ts` + CI; ampliar conforme estratégia se mais fluxos forem exigidos |
 | BP1-3 | P1 | Enforcement de escopo por canal | **Implementado no código atual:** `requirePermission` em [`server/auth.ts`](../../../server/auth.ts) valida `x-bizcode-channel` opcional contra `AuthScope.channels`; cabeçalho inválido retorna `400` e canal fora do escopo retorna `403`. Coberto por [`tests/server/scope-channel.test.ts`](../../../tests/server/scope-channel.test.ts) |
 | BP1-4 | P1 | Chat interno (escopo mínimo) | Implementado com `/api/chat/conversations`, `/api/chat/messages`, contador de não lidas via `Notification` (`chat_message`), histórico paginado e rota de UI `/chat` em `src/pages/chat/index.tsx` |
-| BP1-5 | P1 | Preparação ETL de clientes DBF (#51) | Levantamento documentado em `scripts/MIGRACION_PROGRAMA_VIEJO.md` (mapeamento explícito `COND`/`BAJA`/`CREDITO` e política de rejeição); sem implementação produtiva do ETL de clientes nesta fase |
+| BP1-5 | P1 | ETL de clientes DBF (#51) | **Concluído (PR #120):** ETL v1 a partir de `CLIENTES.DBF` via `legacyClienteDbf.ts` + `migrate-from-dbf.ts` com `clienteBodySchema`; mapeamento e rejeições em `scripts/MIGRACION_PROGRAMA_VIEJO.md`; placeholders `91001`–`91010` apenas sem mestre com linhas; fora do escopo v1: `SALDO`, `FPAGO`, `ZONA` |
 
 ## Estado do repositório vs este pacote
 

--- a/docs/referencias/02-inventario-dbf-indice-maestro.md
+++ b/docs/referencias/02-inventario-dbf-indice-maestro.md
@@ -43,7 +43,7 @@ node scripts/_generate-referencias-02-table.mjs docs/referencias/exports/inventa
 | CLAS09.DBF | 0 | 99 | B | pendiente |
 | CLAS10.DBF | 0 | 99 | B | pendiente |
 | CLAVES.DBF | 8 | 1242 | C | pendiente |
-| CLIENTES.DBF | 2310 | 2575999 | C | pendiente |
+| CLIENTES.DBF | 2310 | 2575999 | C | cubierto-script |
 | COLORES.DBF | 23 | 2783 | B | pendiente |
 | COMIS.DBF | 96191 | 7022457 | D | pendiente |
 | CONCEPTO.DBF | 5 | 214 | B | pendiente |

--- a/docs/referencias/04-relaciones-evidenciadas-en-archivos.md
+++ b/docs/referencias/04-relaciones-evidenciadas-en-archivos.md
@@ -27,7 +27,7 @@ Según [`02-inventario-dbf-indice-maestro.md`](02-inventario-dbf-indice-maestro.
 
 | Archivo | recordCount (aprox.) | Nota |
 |---------|----------------------|------|
-| `CLIENTES.DBF` | 2310 | Tabla de clientes con datos en esta copia (a diferencia del escenario solo-placeholder del script de migración actual). |
+| `CLIENTES.DBF` | 2310 | Tabla de clientes con datos en esta copia; `npm run migrate:dbf` importa filas reales cuando el archivo está presente bajo `PROGRAMA_VIEJO_ROOT` (placeholders `91001`–`91010` solo si no hay maestro con filas; ver #51 / `MIGRACION_PROGRAMA_VIEJO.md`). |
 | `FACT.DBF` | 418354 | Volumen alto; documento comercial agregado o detalle a confirmar leyendo campos en `exports/inventario-dbf-volcado.md`. |
 | `CCTE_V.DBF` | 177399 | Cuenta corriente o vista voluminosa; revisar sección en volcado. |
 | `PVAR.DBF` | 0 | Sin filas en esta copia (coherente con [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../scripts/MIGRACION_PROGRAMA_VIEJO.md)). |

--- a/docs/referencias/07-mapa-modulos-interconexion-y-estrategia.md
+++ b/docs/referencias/07-mapa-modulos-interconexion-y-estrategia.md
@@ -24,7 +24,7 @@
 ## 3. Estrategia de implementación sugerida (BizCode)
 
 1. **Estabilizar maestros ya migrados** — `Rubro`, `Articulo` desde `PVAR`/`PVAR2` (script actual); completar descripciones cuando haya datos en `PVAR` o fuente alternativa (`ARTIC.DBF` tiene 2038 registros en esta copia).
-2. **`Cliente`** — sustituir placeholders: leer estructura y muestras de `CLIENTES.DBF`, mapear a `Cliente` en Prisma y ampliar `migrate-from-dbf.ts` (o script dedicado).
+2. **`Cliente`** — **v1 implementado (#51, PR #120):** ETL desde `CLIENTES.DBF` en [`migrate-from-dbf.ts`](../../scripts/migrate-from-dbf.ts) + [`legacyClienteDbf.ts`](../../src/lib/migration/legacyClienteDbf.ts); placeholders solo sin maestro con filas; ver [`scripts/MIGRACION_PROGRAMA_VIEJO.md`](../../scripts/MIGRACION_PROGRAMA_VIEJO.md).
 3. **`Factura` / `FacturaItem`** — analizar `FACT.DBF`, `DET_COMP`, `ENCAB*`, `IVA_V` para proponer mapeo; volumen alto: migración por lotes y pruebas en subconjunto.
 4. **Cuenta corriente / pagos** — `CCTE_V`, `PAGOS`, `MOV_STK` en fase posterior según prioridad de negocio.
 5. **Validación API** — alinear `POST/PUT` con esquemas Zod/OpenAPI antes de exponer ETL masivo.

--- a/docs/referencias/10-plan-implementaciones-futuras-bizcode.md
+++ b/docs/referencias/10-plan-implementaciones-futuras-bizcode.md
@@ -5,8 +5,8 @@
 ## Corto plazo (técnico)
 
 1. **Validación server-side** de `POST/PUT` en rutas que hoy pasan `req.body` directo a Prisma — coherente con Zod del frontend y OpenAPI.
-2. **Extender ETL** cuando exista tabla real de clientes en DBF (mapear y reemplazar placeholders).
-3. **Tests de integración** de migración con copia mínima de DBF en fixtures (si se acuerda política de datos).
+2. ~~**Extender ETL** cuando exista tabla real de clientes en DBF~~ — **hecho (#51, PR #120):** `CLIENTES.DBF` en `migrate-from-dbf.ts`; ver `scripts/MIGRACION_PROGRAMA_VIEJO.md`.
+3. ~~**Tests de integración** de migración con copia mínima de DBF en fixtures~~ — **hecho (#73):** `tests/integration/dbf-migration.integration.test.ts` y guías en `docs/*/guides/*dbf*`.
 
 ## Medio plazo (dominio)
 

--- a/docs/referencias/bloques/C-terceros/CLIENTES-ficha.md
+++ b/docs/referencias/bloques/C-terceros/CLIENTES-ficha.md
@@ -1,7 +1,7 @@
 # Ficha: `CLIENTES.DBF`
 
 - **Grupo:** C — Terceros y operaciones
-- **Estado:** ETL v1 en `scripts/migrate-from-dbf.ts` cuando el archivo tiene registros
+- **Estado:** ETL v1 implementado (#51, PR #120) en `scripts/migrate-from-dbf.ts` cuando el archivo tiene registros
 
 ## Evidencia numérica
 

--- a/docs/referencias/bloques/README.md
+++ b/docs/referencias/bloques/README.md
@@ -8,7 +8,7 @@
 |-------|-------------|----------------------------|------------|-------|
 | A | Metadatos/listados | 37 | *parcial* | Ficha: [A-metadatos/LIST_CLI-ficha.md](A-metadatos/LIST_CLI-ficha.md); volcado global |
 | B | Maestros comerciales | 38 | *parcial* | Fichas: [B-maestros/PVAR-ficha.md](B-maestros/PVAR-ficha.md), [B-maestros/PVAR2-ficha.md](B-maestros/PVAR2-ficha.md); volcado global |
-| C | Terceros/operaciones | 11 | *parcial* | [C-terceros/CLIENTES-ficha.md](C-terceros/CLIENTES-ficha.md); volcado global |
+| C | Terceros/operaciones | 11 | *parcial* | [C-terceros/CLIENTES-ficha.md](C-terceros/CLIENTES-ficha.md) — `CLIENTES.DBF` con ETL v1 en script (#51); volcado global |
 | D | Documentos comerciales | 17 | 0% | Volcado global [`exports/inventario-dbf-volcado.md`](../exports/inventario-dbf-volcado.md) |
 | E | Auxiliares/históricos | 4 | 0% | Idem |
 | F | Fuera de sistema/ (DOS, esc) | N/A | — | Principalmente no-DBF |

--- a/docs/referencias/exports/inventario-dbf-volcado.md
+++ b/docs/referencias/exports/inventario-dbf-volcado.md
@@ -34,7 +34,7 @@
 | CLAS09.DBF | 0 | 99 | *(asignar)* | pendiente |
 | CLAS10.DBF | 0 | 99 | *(asignar)* | pendiente |
 | CLAVES.DBF | 8 | 1242 | *(asignar)* | pendiente |
-| CLIENTES.DBF | 2310 | 2575999 | *(asignar)* | pendiente |
+| CLIENTES.DBF | 2310 | 2575999 | C | cubierto-script |
 | COLORES.DBF | 23 | 2783 | *(asignar)* | pendiente |
 | COMIS.DBF | 96191 | 7022457 | *(asignar)* | pendiente |
 | CONCEPTO.DBF | 5 | 214 | *(asignar)* | pendiente |


### PR DESCRIPTION
## Summary

- Sync trilingual DBF migration testing guides with ETL #51 / PR #120 (real `CLIENTES.DBF` import, conditional placeholders).
- Update master plan BP1-5 (en/es/pt-br) to **Done**.
- Add [Unreleased] changelog entries (en/es/pt-br).
- Refresh legacy references (10-plan, 07-mapa, 04-relaciones, inventarios, CLIENTES ficha).

## Related

- Closes #51 (documentation closure; code in PR #120)
- Code: PR #120

## Test plan

- [x] `npm run check:docs-map`
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test`
- [x] `npm run test:integration`

Made with [Cursor](https://cursor.com)