### PR TITLE
chore(compras): close #135 — tests, user docs, verification

### DIFF
--- a/docs/en/user/manual-logistics.md
+++ b/docs/en/user/manual-logistics.md
@@ -22,8 +22,22 @@ With **`orders.create`**, open the new-order form, enter customer id, date, opti
 
 Users with **`orders.dispatch`** or **`orders.deliver.confirm`** can change order state per UI controls (`PUT /api/ordenes-entrega/:id`).
 
+## Purchase orders
+
+Open **Purchasing** (`/compras`) from the sidebar. The route is gated by the tenant module **`logistics.purchases`** and is visible to roles such as **owner**, **manager**, and **warehouse_lead** (see navigation configuration in the product).
+
+| Permission | Use |
+|------------|-----|
+| `suppliers.read` | List and view purchase orders |
+| `suppliers.manage` | Create, edit draft orders, send, cancel, and receive |
+| `inventory.adjust` | Required together with `suppliers.manage` on **receive** (stock increment) |
+
+**Status flow:** `draft` → `sent` → `received` (when all lines are fully received) or `cancelled`. While status remains `sent`, you may **receive partial quantities** per line; each receipt creates a `StockAjuste` with motivo `compra` and updates article stock in a single transaction.
+
+Typical API paths: `GET/POST /api/compras`, `GET/PUT /api/compras/{id}`, `POST /api/compras/{id}/send`, `POST /api/compras/{id}/cancel`, `POST /api/compras/{id}/receive`.
+
 ## API reference
 
-[`docs/api/openapi.yaml`](../../api/openapi.yaml) — paths `/api/ordenes-entrega`.
+[`docs/api/openapi.yaml`](../../api/openapi.yaml) — paths `/api/ordenes-entrega`, `/api/compras`.
 
 **Other languages:** [Español](../../es/user/manual-logistica.md) · [Português](../../pt-br/user/manual-logistica.md)

--- a/docs/es/user/manual-logistica.md
+++ b/docs/es/user/manual-logistica.md
@@ -22,8 +22,22 @@ Con **`orders.create`**, abra el formulario de nueva orden, ingrese id de client
 
 Usuarios con **`orders.dispatch`** o **`orders.deliver.confirm`** pueden cambiar el estado de la orden según los controles de la UI (`PUT /api/ordenes-entrega/:id`).
 
+## Órdenes de compra
+
+Abra **Compras** (`/compras`) desde el menú lateral. La ruta depende del módulo de tenant **`logistics.purchases`** y es visible para roles como **owner**, **manager** y **warehouse_lead** (según la configuración de navegación del producto).
+
+| Permiso | Uso |
+|---------|-----|
+| `suppliers.read` | Listar y ver órdenes de compra |
+| `suppliers.manage` | Crear, editar borradores, enviar, cancelar y recibir |
+| `inventory.adjust` | Obligatorio junto con `suppliers.manage` en **recibir** (incremento de stock) |
+
+**Flujo de estados:** `draft` → `sent` → `received` (cuando todas las líneas se reciben por completo) o `cancelled`. Mientras el estado sea `sent`, puede **recibir cantidades parciales** por línea; cada recepción crea un `StockAjuste` con motivo `compra` y actualiza el stock del artículo en una sola transacción.
+
+Rutas API habituales: `GET/POST /api/compras`, `GET/PUT /api/compras/{id}`, `POST /api/compras/{id}/send`, `POST /api/compras/{id}/cancel`, `POST /api/compras/{id}/receive`.
+
 ## Referencia API
 
-[`docs/api/openapi.yaml`](../../api/openapi.yaml) — rutas `/api/ordenes-entrega`.
+[`docs/api/openapi.yaml`](../../api/openapi.yaml) — rutas `/api/ordenes-entrega`, `/api/compras`.
 
 **Otros idiomas:** [English](../../en/user/manual-logistics.md) · [Português](../../pt-br/user/manual-logistica.md)

--- a/docs/pt-br/user/manual-logistica.md
+++ b/docs/pt-br/user/manual-logistica.md
@@ -22,8 +22,22 @@ Com **`orders.create`**, abra o formulário de nova ordem, informe id do cliente
 
 Usuários com **`orders.dispatch`** ou **`orders.deliver.confirm`** podem alterar o estado da ordem pelos controles da UI (`PUT /api/ordenes-entrega/:id`).
 
+## Ordens de compra
+
+Abra **Compras** (`/compras`) na barra lateral. A rota depende do módulo do tenant **`logistics.purchases`** e é visível para papéis como **owner**, **manager** e **warehouse_lead** (conforme a configuração de navegação do produto).
+
+| Permissão | Uso |
+|-----------|-----|
+| `suppliers.read` | Listar e ver ordens de compra |
+| `suppliers.manage` | Criar, editar rascunhos, enviar, cancelar e receber |
+| `inventory.adjust` | Obrigatório junto com `suppliers.manage` no **recebimento** (incremento de estoque) |
+
+**Fluxo de status:** `draft` → `sent` → `received` (quando todas as linhas forem recebidas por completo) ou `cancelled`. Enquanto o status for `sent`, é possível **receber quantidades parciais** por linha; cada recebimento cria um `StockAjuste` com motivo `compra` e atualiza o estoque do artigo em uma única transação.
+
+Rotas API usuais: `GET/POST /api/compras`, `GET/PUT /api/compras/{id}`, `POST /api/compras/{id}/send`, `POST /api/compras/{id}/cancel`, `POST /api/compras/{id}/receive`.
+
 ## Referência API
 
-[`docs/api/openapi.yaml`](../../api/openapi.yaml) — rotas `/api/ordenes-entrega`.
+[`docs/api/openapi.yaml`](../../api/openapi.yaml) — rotas `/api/ordenes-entrega`, `/api/compras`.
 
 **Outros idiomas:** [English](../../en/user/manual-logistics.md) · [Español](../../es/user/manual-logistica.md)

--- a/tests/api/compras.test.ts
+++ b/tests/api/compras.test.ts
@@ -4,30 +4,34 @@ import type { PrismaClient } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
 import { createApp } from '../../server/createApp'
 
-const ordenIncludeRow = {
-  id: 1,
-  tenantId: 1,
-  proveedorId: 2,
-  estado: 'draft',
-  total: new Decimal(50),
-  fechaEstimada: null,
-  nota: null,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  proveedor: { id: 2, codigo: 1, rsocial: 'Prov SA' },
-  items: [
-    {
-      id: 10,
-      ordenCompraId: 1,
-      articuloId: 3,
-      cantidad: 5,
-      cantidadRecibida: 0,
-      costoUnitario: new Decimal(10),
-      subtotal: new Decimal(50),
-      articulo: { id: 3, codigo: 100, descripcion: 'Prod' },
-    },
-  ],
+function buildOrdenRow(estado: string, cantidadRecibida = 0) {
+  return {
+    id: 1,
+    tenantId: 1,
+    proveedorId: 2,
+    estado,
+    total: new Decimal(50),
+    fechaEstimada: null,
+    nota: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    proveedor: { id: 2, codigo: 1, rsocial: 'Prov SA' },
+    items: [
+      {
+        id: 10,
+        ordenCompraId: 1,
+        articuloId: 3,
+        cantidad: 5,
+        cantidadRecibida,
+        costoUnitario: new Decimal(10),
+        subtotal: new Decimal(50),
+        articulo: { id: 3, codigo: 100, descripcion: 'Prod' },
+      },
+    ],
+  }
 }
+
+const ordenIncludeRow = buildOrdenRow('draft')
 
 function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
   return {
@@ -78,11 +82,15 @@ function buildPrismaMock(overrides: Partial<Record<string, unknown>> = {}): Pris
   } as unknown as PrismaClient
 }
 
+function setupComprasAuth(role = 'warehouse_lead') {
+  process.env.NODE_ENV = 'test'
+  process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+  process.env.BIZCODE_TEST_ROLE = role
+}
+
 describe('GET /api/compras', () => {
   beforeEach(() => {
-    process.env.NODE_ENV = 'test'
-    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
-    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    setupComprasAuth()
   })
 
   it('returns paginated purchase orders', async () => {
@@ -93,21 +101,160 @@ describe('GET /api/compras', () => {
   })
 
   it('returns 403 without suppliers.read', async () => {
-    process.env.BIZCODE_TEST_ROLE = 'driver'
+    setupComprasAuth('driver')
     const app = createApp(buildPrismaMock())
     await request(app).get('/api/compras').expect(403)
   })
 })
 
+describe('GET /api/compras/:id', () => {
+  beforeEach(() => {
+    setupComprasAuth()
+  })
+
+  it('returns purchase order detail', async () => {
+    const app = createApp(buildPrismaMock())
+    const res = await request(app).get('/api/compras/1').expect(200)
+    expect(res.body.data.id).toBe(1)
+  })
+
+  it('returns 404 when not found', async () => {
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+    const app = createApp(prisma)
+    await request(app).get('/api/compras/99').expect(404)
+  })
+})
+
+describe('POST /api/compras', () => {
+  beforeEach(() => {
+    setupComprasAuth()
+  })
+
+  it('creates draft purchase order', async () => {
+    const app = createApp(buildPrismaMock())
+    const res = await request(app)
+      .post('/api/compras')
+      .send({
+        proveedorId: 2,
+        items: [{ articuloId: 3, cantidad: 5, costoUnitario: 10 }],
+      })
+      .expect(201)
+    expect(res.body.data.estado).toBe('draft')
+  })
+
+  it('returns 403 without suppliers.manage', async () => {
+    setupComprasAuth('driver')
+    const app = createApp(buildPrismaMock())
+    await request(app)
+      .post('/api/compras')
+      .send({
+        proveedorId: 2,
+        items: [{ articuloId: 3, cantidad: 1, costoUnitario: 10 }],
+      })
+      .expect(403)
+  })
+})
+
+describe('PUT /api/compras/:id', () => {
+  beforeEach(() => {
+    setupComprasAuth()
+  })
+
+  it('updates draft purchase order', async () => {
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: 1, estado: 'draft' }),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ ...ordenIncludeRow, nota: 'Updated' }),
+      },
+    })
+    prisma.$transaction = vi.fn(async (fn: unknown) => {
+      if (typeof fn === 'function') {
+        return (fn as (tx: PrismaClient) => Promise<unknown>)(prisma)
+      }
+      return fn
+    }) as PrismaClient['$transaction']
+    const app = createApp(prisma)
+    const res = await request(app).put('/api/compras/1').send({ nota: 'Updated' }).expect(200)
+    expect(res.body.data.nota).toBe('Updated')
+  })
+
+  it('returns 422 when order is not draft', async () => {
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: 1, estado: 'sent' }),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    })
+    const app = createApp(prisma)
+    const res = await request(app).put('/api/compras/1').send({ nota: 'X' }).expect(422)
+    expect(res.body.error).toBe('ORDER_NOT_EDITABLE')
+  })
+})
+
+describe('POST /api/compras/:id/send', () => {
+  beforeEach(() => {
+    setupComprasAuth()
+  })
+
+  it('marks draft order as sent', async () => {
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(ordenIncludeRow),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ ...ordenIncludeRow, estado: 'sent' }),
+      },
+    })
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/compras/1/send').expect(200)
+    expect(res.body.data.estado).toBe('sent')
+  })
+})
+
+describe('POST /api/compras/:id/cancel', () => {
+  beforeEach(() => {
+    setupComprasAuth()
+  })
+
+  it('cancels sent order', async () => {
+    const sentOrder = buildOrdenRow('sent')
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: 1, estado: 'sent' }),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ ...sentOrder, estado: 'cancelled' }),
+      },
+    })
+    const app = createApp(prisma)
+    const res = await request(app).post('/api/compras/1/cancel').expect(200)
+    expect(res.body.data.estado).toBe('cancelled')
+  })
+})
+
 describe('POST /api/compras/:id/receive', () => {
   beforeEach(() => {
-    process.env.NODE_ENV = 'test'
-    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
-    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    setupComprasAuth()
   })
 
   it('returns 403 without inventory.adjust', async () => {
-    process.env.BIZCODE_TEST_ROLE = 'seller'
+    setupComprasAuth('seller')
     const app = createApp(buildPrismaMock())
     await request(app)
       .post('/api/compras/1/receive')
@@ -115,8 +262,8 @@ describe('POST /api/compras/:id/receive', () => {
       .expect(403)
   })
 
-  it('receives stock with audit', async () => {
-    const sentOrder = { ...ordenIncludeRow, estado: 'sent' }
+  it('receives stock with audit when fully received', async () => {
+    const sentOrder = buildOrdenRow('sent')
     const auditCreate = vi.fn().mockResolvedValue({ id: 1 })
     const prisma = buildPrismaMock({
       auditEvent: { create: auditCreate },
@@ -144,5 +291,34 @@ describe('POST /api/compras/:id/receive', () => {
       .expect(200)
     expect(res.body.data.estado).toBe('received')
     expect(auditCreate).toHaveBeenCalled()
+  })
+
+  it('keeps estado sent on partial receive', async () => {
+    const sentOrder = buildOrdenRow('sent')
+    const prisma = buildPrismaMock({
+      ordenCompra: {
+        count: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(sentOrder),
+        update: vi.fn().mockResolvedValue({
+          ...sentOrder,
+          estado: 'sent',
+          items: [{ ...sentOrder.items[0], cantidadRecibida: 2 }],
+        }),
+      },
+    })
+    prisma.$transaction = vi.fn(async (fn: unknown) => {
+      if (typeof fn === 'function') {
+        return (fn as (tx: PrismaClient) => Promise<unknown>)(prisma)
+      }
+      return fn
+    }) as PrismaClient['$transaction']
+    const app = createApp(prisma)
+    const res = await request(app)
+      .post('/api/compras/1/receive')
+      .send({ lines: [{ itemId: 10, cantidad: 2 }] })
+      .expect(200)
+    expect(res.body.data.estado).toBe('sent')
+    expect(prisma.stockAjuste.create).toHaveBeenCalled()
   })
 })

--- a/tests/api/contract.test.ts
+++ b/tests/api/contract.test.ts
@@ -99,6 +99,29 @@ const proveedorInput = {
   activo: true,
 }
 
+const ordenCompraContractRow = {
+  id: 1,
+  tenantId: 1,
+  proveedorId: 1,
+  estado: 'draft',
+  total: new Decimal(20),
+  fechaEstimada: null,
+  nota: null,
+  proveedor: { id: 1, codigo: 1, rsocial: 'Prov' },
+  items: [
+    {
+      id: 10,
+      ordenCompraId: 1,
+      articuloId: 1,
+      cantidad: 2,
+      cantidadRecibida: 0,
+      costoUnitario: new Decimal(10),
+      subtotal: new Decimal(20),
+      articulo: { id: 1, codigo: 1, descripcion: 'Prod' },
+    },
+  ],
+}
+
 function buildPrisma(): PrismaClient {
   const facturaCreate = vi.fn().mockResolvedValue(facturaRow)
   // tx-level cliente.update: returns the financial summary the route uses for the credit check
@@ -198,21 +221,11 @@ function buildPrisma(): PrismaClient {
       findMany: vi.fn().mockResolvedValue([]),
     },
     ordenCompra: {
-      count: vi.fn().mockResolvedValue(0),
-      findMany: vi.fn().mockResolvedValue([]),
-      findFirst: vi.fn().mockResolvedValue(null),
-      create: vi.fn().mockResolvedValue({
-        id: 1,
-        tenantId: 1,
-        proveedorId: 1,
-        estado: 'draft',
-        total: new Decimal(0),
-        fechaEstimada: null,
-        nota: null,
-        proveedor: { id: 1, codigo: 1, rsocial: 'Prov' },
-        items: [],
-      }),
-      update: vi.fn(),
+      count: vi.fn().mockResolvedValue(1),
+      findMany: vi.fn().mockResolvedValue([ordenCompraContractRow]),
+      findFirst: vi.fn().mockResolvedValue(ordenCompraContractRow),
+      create: vi.fn().mockResolvedValue(ordenCompraContractRow),
+      update: vi.fn().mockResolvedValue(ordenCompraContractRow),
     },
     ordenCompraItem: { deleteMany: vi.fn(), update: vi.fn() },
     ordenEntrega: {
@@ -766,6 +779,89 @@ describe('API — contrato OpenAPI', () => {
       })
       .expect(201)
     await assertMatchesOpenApi('/api/compras', 'post', '201', res.body)
+  })
+
+  it('GET /api/compras/{id}', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    const app = createApp(prisma)
+    const res = await request(app).get('/api/compras/1').expect(200)
+    await assertMatchesOpenApi('/api/compras/{id}', 'get', '200', res.body)
+  })
+
+  it('PUT /api/compras/{id}', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    const p = buildPrisma()
+    vi.mocked(p.ordenCompra.findFirst).mockResolvedValueOnce({ id: 1, estado: 'draft' } as never)
+    vi.mocked(p.ordenCompra.update).mockResolvedValueOnce({
+      ...ordenCompraContractRow,
+      nota: 'Contract note',
+    } as never)
+    p.$transaction = vi.fn(async (fn: unknown) => {
+      if (typeof fn === 'function') {
+        return (fn as (tx: PrismaClient) => Promise<unknown>)(p)
+      }
+      return fn
+    }) as PrismaClient['$transaction']
+    const app = createApp(p)
+    const res = await request(app).put('/api/compras/1').send({ nota: 'Contract note' }).expect(200)
+    await assertMatchesOpenApi('/api/compras/{id}', 'put', '200', res.body)
+  })
+
+  it('POST /api/compras/{id}/send', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    const p = buildPrisma()
+    vi.mocked(p.ordenCompra.update).mockResolvedValueOnce({
+      ...ordenCompraContractRow,
+      estado: 'sent',
+    } as never)
+    const app = createApp(p)
+    const res = await request(app).post('/api/compras/1/send').expect(200)
+    await assertMatchesOpenApi('/api/compras/{id}/send', 'post', '200', res.body)
+  })
+
+  it('POST /api/compras/{id}/cancel', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    const p = buildPrisma()
+    vi.mocked(p.ordenCompra.findFirst).mockResolvedValueOnce({ id: 1, estado: 'sent' } as never)
+    vi.mocked(p.ordenCompra.update).mockResolvedValueOnce({
+      ...ordenCompraContractRow,
+      estado: 'cancelled',
+    } as never)
+    const app = createApp(p)
+    const res = await request(app).post('/api/compras/1/cancel').expect(200)
+    await assertMatchesOpenApi('/api/compras/{id}/cancel', 'post', '200', res.body)
+  })
+
+  it('POST /api/compras/{id}/receive', async () => {
+    process.env.BIZCODE_TEST_AUTH_BYPASS = 'true'
+    process.env.BIZCODE_TEST_ROLE = 'warehouse_lead'
+    const sentRow = { ...ordenCompraContractRow, estado: 'sent' }
+    const p = buildPrisma()
+    vi.mocked(p.ordenCompra.findFirst).mockResolvedValueOnce({
+      ...sentRow,
+      items: ordenCompraContractRow.items.map((i) => ({ ...i, cantidadRecibida: 0 })),
+    } as never)
+    vi.mocked(p.ordenCompra.update).mockResolvedValueOnce({
+      ...sentRow,
+      estado: 'received',
+      items: ordenCompraContractRow.items.map((i) => ({ ...i, cantidadRecibida: i.cantidad })),
+    } as never)
+    p.$transaction = vi.fn(async (fn: unknown) => {
+      if (typeof fn === 'function') {
+        return (fn as (tx: PrismaClient) => Promise<unknown>)(p)
+      }
+      return fn
+    }) as PrismaClient['$transaction']
+    const app = createApp(p)
+    const res = await request(app)
+      .post('/api/compras/1/receive')
+      .send({ lines: [{ itemId: 10, cantidad: 2 }] })
+      .expect(200)
+    await assertMatchesOpenApi('/api/compras/{id}/receive', 'post', '200', res.body)
   })
 
   it('GET /api/cobranzas/vencidas', async () => {


### PR DESCRIPTION
## Summary

- Complete OpenAPI contract tests for all \/api/compras\ paths (GET list/detail, POST create, PUT draft, send, cancel, receive).
- Expand API integration tests in \	ests/api/compras.test.ts\ (RBAC, partial receive, state transitions).
- Add purchase orders section to logistics user manuals (en/es/pt-BR).

Closes #135

## Test plan

- [x] \
pm run lint\
- [x] \
pm run type-check\
- [x] \
px vitest run --maxWorkers=2\ (739 tests)
- [ ] CI green on merge

Made with [Cursor](https://cursor.com)