### PR TITLE
feat(ci): selective Turborepo cache and workspace filters (#158)

### DIFF
--- a/.github/actions/turbo-cache/action.yml
+++ b/.github/actions/turbo-cache/action.yml
@@ -1,0 +1,12 @@
+name: Turbo cache
+description: Restore and save Turborepo local cache (.turbo) for CI runs
+runs:
+  using: composite
+  steps:
+    - name: Cache Turborepo
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-

--- a/.github/workflows/backend-validation.yml
+++ b/.github/workflows/backend-validation.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -62,11 +64,17 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: npx prisma generate
+
+      - name: TypeScript type-check and lint (server workspace)
+        run: pnpm exec turbo run type-check lint --filter=@bizcode/server...
 
       - name: Validate Prisma schema
         run: npx prisma validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -45,6 +47,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -143,7 +148,7 @@ jobs:
           NODE
 
       - name: ESLint (jsx-a11y y TypeScript — cero advertencias)
-        run: pnpm run lint
+        run: pnpm exec turbo run lint
 
       - name: API contract tests (OpenAPI / Ajv)
         run: npx vitest run tests/api/contract.test.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,40 @@ on:
       - main
       - develop
       - 'feature/**'
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'prisma/**'
+      - 'Dockerfile'
+      - 'Dockerfile.frontend'
+      - 'docker-compose*.yml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - 'tsconfig.json'
+      - 'eslint.config.mjs'
+      - 'vitest.config.ts'
+      - '.github/workflows/deploy.yml'
   pull_request:
     branches:
       - main
       - develop
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'prisma/**'
+      - 'Dockerfile'
+      - 'Dockerfile.frontend'
+      - 'docker-compose*.yml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
+      - 'tsconfig.json'
+      - 'eslint.config.mjs'
+      - 'vitest.config.ts'
+      - '.github/workflows/deploy.yml'
   workflow_dispatch:
     inputs:
       run_deploy:
@@ -35,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -47,6 +79,9 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -57,7 +92,7 @@ jobs:
         run: pnpm run type-check
 
       - name: Run lint
-        run: pnpm run lint
+        run: pnpm exec turbo run lint
 
       - name: Run tests
         run: pnpm run test

--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -9,7 +9,6 @@ on:
     branches: [main, develop]
     paths:
       - 'apps/web/src/**'
-      - 'apps/server/**'
       - 'packages/**'
       - 'prisma/**'
       - 'tests/**'
@@ -23,7 +22,6 @@ on:
     branches: [main, develop]
     paths:
       - 'apps/web/src/**'
-      - 'apps/server/**'
       - 'packages/**'
       - 'prisma/**'
       - 'tests/**'
@@ -62,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -74,17 +74,20 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: npx prisma generate
 
-      - name: TypeScript type-check
-        run: pnpm run type-check
+      - name: TypeScript type-check (web workspace)
+        run: pnpm exec turbo run type-check --filter=@bizcode/web...
 
-      - name: ESLint with jsx-a11y
-        run: pnpm run lint
+      - name: ESLint with jsx-a11y (web workspace)
+        run: pnpm exec turbo run lint --filter=@bizcode/web...
 
       - name: Unit tests with coverage
         run: pnpm run test:coverage

--- a/.github/workflows/qa-validation.yml
+++ b/.github/workflows/qa-validation.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -57,6 +59,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -114,6 +119,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -123,6 +130,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -161,6 +171,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -170,6 +182,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -237,6 +252,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -246,6 +263,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -266,6 +286,8 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -275,6 +297,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Turborepo cache
+        uses: ./.github/actions/turbo-cache
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 node_modules/
+.pnpm-store/
+.turbo/
+package-lock.json
 data/documentos-compra/
 data/documentos-compra-templates/
 dist/
+packages/*/dist/
 build/
 
 # Local legacy / reference copy (not part of the repo tree; match casing on disk / Git)

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,11 @@
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint . --ext .ts --max-warnings 0"
   },
+  "turbo": {
+    "type-check": {
+      "outputs": []
+    }
+  },
   "dependencies": {
     "@bizcode/types": "workspace:*"
   }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -3,17 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2020"],
     "jsx": "preserve",
-    "forceConsistentCasingInFileNames": true,
-    "paths": {
-      "@/*": ["../web/src/*"],
-      "@components/*": ["../web/src/components/*"],
-      "@pages/*": ["../web/src/pages/*"],
-      "@lib/*": ["../web/src/lib/*"],
-      "@hooks/*": ["../web/src/hooks/*"],
-      "@store/*": ["../web/src/store/*"],
-      "@bizcode/types": ["../../packages/types/src/index.ts"],
-      "@bizcode/api-client": ["../../packages/api-client/src/index.ts"]
-    }
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["./**/*.ts"]
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -5,7 +5,14 @@
     "jsx": "preserve",
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@bizcode/types": ["../../packages/types/src/index.ts"]
+      "@/*": ["../web/src/*"],
+      "@components/*": ["../web/src/components/*"],
+      "@pages/*": ["../web/src/pages/*"],
+      "@lib/*": ["../web/src/lib/*"],
+      "@hooks/*": ["../web/src/hooks/*"],
+      "@store/*": ["../web/src/store/*"],
+      "@bizcode/types": ["../../packages/types/src/index.ts"],
+      "@bizcode/api-client": ["../../packages/api-client/src/index.ts"]
     }
   },
   "include": ["./**/*.ts"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,11 @@
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src --ext .ts,.tsx --max-warnings 0"
   },
+  "turbo": {
+    "type-check": {
+      "outputs": []
+    }
+  },
   "dependencies": {
     "@bizcode/api-client": "workspace:*",
     "@bizcode/types": "workspace:*"

--- a/docs/en/quality/ci-cd.md
+++ b/docs/en/quality/ci-cd.md
@@ -4,6 +4,25 @@
 
 BizCode uses GitHub Actions for continuous integration. The pipeline is defined in `.github/workflows/ci.yml`.
 
+## Monorepo and Turborepo selective CI (#158)
+
+BizCode is a **pnpm workspace** (`apps/web`, `apps/server`, `packages/types`, `packages/api-client`) orchestrated by **Turborepo** (`turbo.json`).
+
+| Mechanism | Purpose |
+|---|---|
+| `turbo.json` `inputs` / `outputs` | Local task cache under `.turbo/` |
+| `.github/actions/turbo-cache` | GitHub Actions cache keyed by `pnpm-lock.yaml` |
+| `pnpm exec turbo run lint` | Workspace-aware ESLint (Quality Gate, deploy) |
+| `turbo run type-check lint --filter=@bizcode/web...` | Frontend validation without the server workspace |
+| `turbo run type-check lint --filter=@bizcode/server...` | Backend validation (server + package dependencies) |
+| Workflow `paths:` filters | Skip jobs when unrelated paths change |
+| Root `pnpm run type-check` | Full-repo `tsc --noEmit` (tests, scripts, e2e) — **unchanged** in Quality Gate |
+| Vitest / Playwright | Rooted at repo level; selective via workflow `paths:`, not `turbo run test --filter` |
+
+`deploy.yml` runs on `push`/`pull_request` only when application, package, Docker, or lockfile paths change; `workflow_dispatch` and `release` triggers are unchanged.
+
+**Limitation:** SBOM regeneration is skipped in CI (`scripts/docs-generate.mjs`); the committed `docs/evidence/sbom-cyclonedx.json` is not drift-checked in CI.
+
 ## Pipeline Stages
 
 ```

--- a/docs/es/quality/ciclo-ci-cd.md
+++ b/docs/es/quality/ciclo-ci-cd.md
@@ -4,6 +4,25 @@
 
 BizCode usa GitHub Actions para integración continua. El pipeline está definido en `.github/workflows/ci.yml`.
 
+## Monorepo y CI selectiva con Turborepo (#158)
+
+BizCode es un **workspace pnpm** (`apps/web`, `apps/server`, `packages/types`, `packages/api-client`) orquestado por **Turborepo** (`turbo.json`).
+
+| Mecanismo | Propósito |
+|---|---|
+| `inputs` / `outputs` en `turbo.json` | Caché local de tareas bajo `.turbo/` |
+| `.github/actions/turbo-cache` | Caché en GitHub Actions con clave `pnpm-lock.yaml` |
+| `pnpm exec turbo run lint` | ESLint por workspace (Quality Gate, deploy) |
+| `turbo run type-check lint --filter=@bizcode/web...` | Validación frontend sin el workspace server |
+| `turbo run type-check lint --filter=@bizcode/server...` | Validación backend (server + dependencias de packages) |
+| Filtros `paths:` en workflows | Omitir jobs cuando solo cambian rutas ajenas |
+| `pnpm run type-check` en raíz | `tsc --noEmit` de todo el repo (tests, scripts, e2e) — **sin cambio** en Quality Gate |
+| Vitest / Playwright | En raíz; selectividad vía `paths:` del workflow, no `turbo run test --filter` |
+
+`deploy.yml` corre en `push`/`pull_request` solo si cambian rutas de app, packages, Docker o lockfile; `workflow_dispatch` y `release` no cambian.
+
+**Limitación:** la regeneración del SBOM se omite en CI (`scripts/docs-generate.mjs`); el `docs/evidence/sbom-cyclonedx.json` commitado no se valida por drift en CI.
+
 ## Etapas del pipeline
 
 ```

--- a/docs/pt-br/quality/ciclo-ci-cd.md
+++ b/docs/pt-br/quality/ciclo-ci-cd.md
@@ -4,6 +4,25 @@
 
 BizCode usa GitHub Actions. Definição: `.github/workflows/ci.yml`.
 
+## Monorepo e CI seletiva com Turborepo (#158)
+
+BizCode é um **workspace pnpm** (`apps/web`, `apps/server`, `packages/types`, `packages/api-client`) orquestrado por **Turborepo** (`turbo.json`).
+
+| Mecanismo | Propósito |
+|---|---|
+| `inputs` / `outputs` em `turbo.json` | Cache local de tarefas em `.turbo/` |
+| `.github/actions/turbo-cache` | Cache no GitHub Actions com chave `pnpm-lock.yaml` |
+| `pnpm exec turbo run lint` | ESLint por workspace (Quality Gate, deploy) |
+| `turbo run type-check lint --filter=@bizcode/web...` | Validação frontend sem o workspace server |
+| `turbo run type-check lint --filter=@bizcode/server...` | Validação backend (server + dependências dos packages) |
+| Filtros `paths:` nos workflows | Pular jobs quando só mudam caminhos irrelevantes |
+| `pnpm run type-check` na raiz | `tsc --noEmit` de todo o repositório (tests, scripts, e2e) — **inalterado** no Quality Gate |
+| Vitest / Playwright | Na raiz; seletividade via `paths:` do workflow, não `turbo run test --filter` |
+
+`deploy.yml` roda em `push`/`pull_request` apenas quando mudam caminhos de app, packages, Docker ou lockfile; gatilhos `workflow_dispatch` e `release` permanecem iguais.
+
+**Limitação:** a regeneração do SBOM é omitida no CI (`scripts/docs-generate.mjs`); o `docs/evidence/sbom-cyclonedx.json` commitado não é verificado por drift no CI.
+
 ## Estágios
 
 ```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "build": "tauri build",
     "preview": "pnpm --filter @bizcode/web preview",
     "type-check": "tsc --noEmit",
+    "type-check:workspaces": "turbo run type-check",
+    "lint:workspaces": "turbo run lint",
     "check:openapi": "tsx scripts/check-openapi.ts",
     "check:openapi-sync": "tsx scripts/validate-openapi-sync.ts",
     "check:logs": "tsx scripts/check-log-sanitization.ts",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,8 +7,13 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "type-check": "tsc --noEmit -p tsconfig.json",
+    "type-check": "tsc -b --pretty false",
     "lint": "eslint src --ext .ts --max-warnings 0"
+  },
+  "turbo": {
+    "type-check": {
+      "outputs": ["dist/**", "tsconfig.tsbuildinfo"]
+    }
   },
   "dependencies": {
     "@bizcode/types": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,12 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "type-check": "tsc --noEmit -p tsconfig.json",
+    "type-check": "tsc -b --pretty false",
     "lint": "eslint src --ext .ts --max-warnings 0"
+  },
+  "turbo": {
+    "type-check": {
+      "outputs": ["dist/**", "tsconfig.tsbuildinfo"]
+    }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+    "eslint.config.mjs"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "vite.config.ts", "index.html", "tailwind.config.js", "postcss.config.js"],
       "outputs": ["dist/**"]
     },
     "dev": {
@@ -14,10 +20,14 @@
       "cache": false
     },
     "type-check": {
-      "dependsOn": ["^type-check"]
+      "dependsOn": ["^type-check"],
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json", "../../tsconfig.json"],
+      "outputs": ["dist/**", "tsconfig.tsbuildinfo"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "inputs": ["$TURBO_DEFAULT$", "eslint.config.mjs", "../../eslint.config.mjs"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- Configure Turborepo task caching (	urbo.json inputs/outputs, globalDependencies) and ignore .turbo/ / .pnpm-store/ locally.
- Add composite action .github/actions/turbo-cache and wire it into Quality Gate, backend/frontend/QA validation, and deploy workflows.
- Scope frontend/backend validation with 	urbo --filter=@bizcode/web... / @bizcode/server...; remove pps/server/** from frontend path triggers; add deploy paths: filters.
- Document monorepo CI behavior in trilingual ci-cd.md files.

Closes #158

## Test plan
- [ ] Quality Gate passes on PR (root 	ype-check unchanged; 	urbo run lint for workspaces).
- [ ] Frontend validation runs only on web/package/test path changes (not server-only diffs).
- [ ] Deploy workflow skipped on docs-only PRs; runs on pps/** or Docker changes.
- [ ] Second CI run shows Turborepo cache restore (.turbo hit) on lint/type-check workspace tasks.

Made with [Cursor](https://cursor.com)